### PR TITLE
Lem issue 92

### DIFF
--- a/wallet/ergvein-wallet.cabal
+++ b/wallet/ergvein-wallet.cabal
@@ -19,6 +19,7 @@ library
   exposed-modules:
     Ergvein.Wallet
     Ergvein.Wallet.Alert
+    Ergvein.Wallet.Alert.Handler
     Ergvein.Wallet.Alert.Type
     Ergvein.Wallet.Clipboard
     Ergvein.Wallet.Elements

--- a/wallet/src/Ergvein/Wallet/Alert.hs
+++ b/wallet/src/Ergvein/Wallet/Alert.hs
@@ -5,7 +5,8 @@
 -- handle*Msg :: Event (Either msg val) -> m (Event val)
 -- ^ sends Left occurences to alert popup and passed Right occurences through.
 -- handle*Msg logs all Left occurences (!)
--- log*Msg -- simply logs the messages w/o sending them to alert popup
+-- log*Msg :: Event (Either msg val) -> m (Event val)
+-- ^ simply logs the Left occurences w/o sending them to alert popup. Passes Right through
 -- This module also reexports common alert types and sets defaultMsgTimeout
 module Ergvein.Wallet.Alert
   (

--- a/wallet/src/Ergvein/Wallet/Alert.hs
+++ b/wallet/src/Ergvein/Wallet/Alert.hs
@@ -1,14 +1,15 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE FunctionalDependencies #-}
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE OverloadedLists #-}
-
--- | Widget to spam alerts in popups. It is better than inplace alert display as
--- it doesn't break layout of elements.
-module Ergvein.Wallet.Alert(
-    alertHandlerWidget
+-- | This module provides helper-functions to post alert messages
+-- It has three groups of functions:
+-- show*Msg :: (Event msg) -> m () -
+-- ^ simply sends message to alert popup w/o logging the message
+-- handle*Msg :: Event (Either msg val) -> m (Event val)
+-- ^ sends Left occurences to alert popup and passed Right occurences through.
+-- handle*Msg logs all Left occurences (!)
+-- log*Msg -- simply logs the messages w/o sending them to alert popup
+-- This module also reexports common alert types and sets defaultMsgTimeout
+module Ergvein.Wallet.Alert
+  (
+    defaultMsgTimeout
   , showDangerMsg
   , showWarnMsg
   , showSuccessMsg
@@ -30,153 +31,17 @@ module Ergvein.Wallet.Alert(
   , logSecondaryMsg
   , logInfoMsg
   , logAlertWith
+  , module Ergvein.Wallet.Alert.Type
   ) where
 
-import Control.Monad
 import Control.Monad.IO.Class
-import Data.Align
-import Data.Bifunctor
-import Data.Coerce
-import Data.Monoid
-import Data.Time
-import GHC.Generics
-import Reflex.Dom
-import Reflex.Host.Class
-
-import Language.Javascript.JSaddle.Types
-
-import Data.List (find)
-import Data.Map.Strict (Map)
-import Data.Text (Text)
-import Reflex hiding (askEvents)
-import Reflex.ExternalRef(readExternalRef)
-
-import qualified Data.Foldable as F
-import qualified Data.Map.Strict as M
-import qualified Data.These as T
-
-import Ergvein.Text
+import Data.Time (getCurrentTime)
+import Ergvein.Wallet.Alert.Type
 import Ergvein.Wallet.Language
 import Ergvein.Wallet.Log.Types
-import Ergvein.Wallet.Monad
-import Ergvein.Wallet.Util
-
-badge :: forall t m a . MonadFrontBase t m => Text -> m a -> m a
-badge clazz = elClass "span" ("badge " <> clazz)
-
-badgePrimary :: forall t m a . MonadFrontBase t m => m a -> m a
-badgePrimary = badge "badge-primary"
-
--- | Helper to find element in map
-findAmongMap :: (a -> Bool) -> Map k a -> Maybe (k, a)
-findAmongMap f = find (f . snd) . M.toList
-
--- | Widget to spam alerts in popups. Call it anywhere in page to start displaying
--- alerts in popups.
-alertHandlerWidget :: forall t m . (MonadLocalized t m, MonadAlertPoster t m, MonadFrontBase t m) => m ()
-alertHandlerWidget = divClass "alert-overlay" $ mdo
-  langD <- getLanguage
-  errE <- newAlertEvent
-  logAlerts errE
-  let
-    accumAlerts :: T.These AlertInfo [Int] -> PushM t (Map Int (Maybe (AlertInfo, Int)))
-    accumAlerts v = do
-      n <- sample . current $ countD
-      let
-        handleNewErr :: AlertInfo -> PushM t (Map Int (Maybe (AlertInfo, Int)))
-        handleNewErr newErr@(AlertInfo _ _ _ _ msg1) = do
-          let mkNew = M.singleton n (Just (newErr, 1))
-          es <- sample . current $ infosD
-          l <- sample . current $ langD
-          pure $ case findAmongMap (\(AlertInfo _ _ _ _ msg2,_) -> (localizedShow l msg1 == localizedShow l msg2)) es of
-            Nothing -> mkNew
-            Just (i, (ei, c)) -> M.singleton i (Just (ei, c+1))
-        handleDeletes :: [Int] -> PushM t (Map Int (Maybe (AlertInfo, Int)))
-        handleDeletes is = pure $ M.fromList $ (\i -> (i, Nothing)) <$> is
-      case v of
-        T.This newErr -> handleNewErr newErr
-        T.That is -> handleDeletes is
-        T.These newErr is -> do
-          remm <- handleDeletes is
-          addm <- handleNewErr newErr
-          pure $ M.union remm addm
-
-    accumAlertsE :: Event t (Map Int (Maybe (AlertInfo, Int)))
-    accumAlertsE = pushAlways accumAlerts (align errE deleteE)
-
-    alertWidgetD :: Int -> (AlertInfo, Int) -> Event t (AlertInfo, Int) -> m (Dynamic t (AlertInfo, Int), Event t ())
-    alertWidgetD _ v vE = do
-      vD <- holdDyn v vE
-      rD <- widgetHoldDyn $ uncurry alertWidget <$> vD
-      let delE = switch . current $ rD
-      pure (vD, delE)
-
-  resD :: Dynamic t (Map Int (Dynamic t (AlertInfo, Int), Event t ())) <- listWithKeyShallowDiff mempty accumAlertsE alertWidgetD
-  let
-    deletesED :: Dynamic t (Map Int (Event t ()))
-    deletesED = fmap snd <$> resD
-
-    infosD :: Dynamic t (Map Int (AlertInfo, Int))
-    infosD = joinDynThroughMap $ fmap fst <$> resD
-
-    deleteE :: Event t [Int]
-    deleteE = switch . current $ do
-      es <- deletesED
-      pure $ fmap M.keys . mergeMap $ es
-    countD :: Dynamic t Int
-    countD = length <$> deletesED
-  pure ()
-
-logAlerts :: forall t m . MonadFrontBase t m => Event t AlertInfo -> m ()
-logAlerts e = postLog $ ffor e $ \AlertInfo{..} -> LogEntry {
-    logTime = alertTime
-  , logSeverity = alertTypeToSeverity alertType
-  , logMessage = localizedShow English alertMessage
-  , logNameSpace = alertNameSpace
-  }
-  where
-        -- | Posting log message
-    postLog :: MonadFrontBase t m => Event t LogEntry -> m ()
-    postLog e = do
-      (_, fire) <- getLogsTrigger
-      performEvent_ $ ffor e $ liftIO . fire
-
--- | Widget that displays alert to user. Fires when destruction timeout is passed.
-alertWidget :: MonadFrontBase t m => AlertInfo -> Int -> m (Event t ())
-alertWidget AlertInfo{..} n = do
-  closeE <- elAttr "div" [
-      ("role" , "alert")
-    , ("class", "alert-popup alert alert-handler col-md-offset-3 col-md-6 col-lg-offset-3 col-lg-6 col-sm-12 " <> alertTypeStyle alertType)
-    , ("style", "margin: 0px; border-radius: 0px; background-color: #ff931e; font-weight: normal; color: #ffffff;")
-    ] $ do
-      when (n > 1) $ badgePrimary $ text $ showt n
-      localizedText alertMessage
-      -- closeLabel <- localized AlertClose
-      -- (e,_) <- elAttr' "div" [("class", "alert-close")] $ do
-      --   let attrs = do
-      --         label <- closeLabel
-      --         pupx -> %, lots of changes in positions and width, added steaky header,…re [
-      --             ("href", "#")
-      --           , ("onclick", "return false;")
-      --           , ("data-tippy-placement", "top")
-      --           , ("title", label)
-      --           , ("class","fas fa-times")
-      --           ]
-      --   elDynAttr "i" attrs $ pure ()
-      -- pure $ domEvent Click e
-      pure never
-  timeoutE <- delay (realToFrac alertTimeout) =<< getPostBuild
-  pure $ leftmost [timeoutE, closeE]
-
--- | Which style to use for specific alert type
-alertTypeStyle :: AlertType -> Text
-alertTypeStyle et = case et of
-  AlertTypeInfo -> "alert-info"
-  AlertTypePrimary -> "alert-primary"
-  AlertTypeSecondary -> "alert-secondary"
-  AlertTypeWarn -> "alert-warning"
-  AlertTypeSuccess -> "alert-success"
-  AlertTypeFail -> "alert-danger"
+import Ergvein.Wallet.Monad.Base
+import Reflex
+import Reflex.ExternalRef (readExternalRef)
 
 -- | Amount of seconds to show messages by default
 defaultMsgTimeout :: Double
@@ -215,7 +80,7 @@ showMsg et e = do
   ns <- readExternalRef =<< getLogsNameSpacesRef
   e' <- performEvent $ ffor e $ \v -> do
     t <- liftIO getCurrentTime
-    pure $ AlertInfo et defaultMsgTimeout ns t v
+    pure $ AlertInfo et defaultMsgTimeout ns t False v
   postAlert e'
 
 -- | Display 'Left' occurences as error messages
@@ -249,7 +114,7 @@ handleAlertWith et e = do
   alertE <- performEvent $ fforMaybe e $ \case
     Left ge -> Just $ do
       t <- liftIO getCurrentTime
-      pure $ AlertInfo et defaultMsgTimeout ns t ge
+      pure $ AlertInfo et defaultMsgTimeout ns t True ge
     Right _ -> Nothing
   _ <- postAlert alertE
   pure $ fmapMaybe (either (const Nothing) Just) e

--- a/wallet/src/Ergvein/Wallet/Alert/Handler.hs
+++ b/wallet/src/Ergvein/Wallet/Alert/Handler.hs
@@ -1,0 +1,144 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE OverloadedLists #-}
+
+-- | Widget to spam alerts in popups. It is better than inplace alert display as
+-- it doesn't break layout of elements.
+module Ergvein.Wallet.Alert.Handler(
+    alertHandlerWidget
+  ) where
+
+import Control.Monad
+import Control.Monad.IO.Class
+import Data.Align
+import Data.Bifunctor
+import Data.Coerce
+import Data.Monoid
+import Data.Time
+import GHC.Generics
+import Reflex.Dom
+import Reflex.Host.Class
+
+import Language.Javascript.JSaddle.Types
+
+import Data.List (find)
+import Data.Map.Strict (Map)
+import Data.Text (Text)
+import Reflex hiding (askEvents)
+import Reflex.ExternalRef(readExternalRef)
+
+import qualified Data.Foldable as F
+import qualified Data.Map.Strict as M
+import qualified Data.These as T
+
+import Ergvein.Text
+import Ergvein.Wallet.Language
+import Ergvein.Wallet.Log.Types
+import Ergvein.Wallet.Monad
+import Ergvein.Wallet.Util
+
+badge :: forall t m a . MonadFrontBase t m => Text -> m a -> m a
+badge clazz = elClass "span" ("badge " <> clazz)
+
+badgePrimary :: forall t m a . MonadFrontBase t m => m a -> m a
+badgePrimary = badge "badge-primary"
+
+-- | Helper to find element in map
+findAmongMap :: (a -> Bool) -> Map k a -> Maybe (k, a)
+findAmongMap f = find (f . snd) . M.toList
+
+-- | Widget to spam alerts in popups. Call it anywhere in page to start displaying
+-- alerts in popups.
+alertHandlerWidget :: forall t m . (MonadLocalized t m, MonadAlertPoster t m, MonadFrontBase t m) => m ()
+alertHandlerWidget = divClass "alert-overlay" $ mdo
+  langD <- getLanguage
+  errE <- newAlertEvent
+  logAlerts $ fforMaybe errE $ \alrt -> if alertDoLog alrt then Just alrt else Nothing
+  let
+    accumAlerts :: T.These AlertInfo [Int] -> PushM t (Map Int (Maybe (AlertInfo, Int)))
+    accumAlerts v = do
+      n <- sample . current $ countD
+      let
+        handleNewErr :: AlertInfo -> PushM t (Map Int (Maybe (AlertInfo, Int)))
+        handleNewErr newErr@(AlertInfo _ _ _ _ _ msg1) = do
+          let mkNew = M.singleton n (Just (newErr, 1))
+          es <- sample . current $ infosD
+          l <- sample . current $ langD
+          let filt = (\(AlertInfo _ _ _ _ _ msg2,_) -> (localizedShow l msg1 == localizedShow l msg2))
+          pure $ case findAmongMap filt es of
+            Nothing -> mkNew
+            Just (i, (ei, c)) -> M.singleton i (Just (ei, c+1))
+        handleDeletes :: [Int] -> PushM t (Map Int (Maybe (AlertInfo, Int)))
+        handleDeletes is = pure $ M.fromList $ (\i -> (i, Nothing)) <$> is
+      case v of
+        T.This newErr -> handleNewErr newErr
+        T.That is -> handleDeletes is
+        T.These newErr is -> do
+          remm <- handleDeletes is
+          addm <- handleNewErr newErr
+          pure $ M.union remm addm
+
+    accumAlertsE :: Event t (Map Int (Maybe (AlertInfo, Int)))
+    accumAlertsE = pushAlways accumAlerts (align errE deleteE)
+
+    alertWidgetD :: Int -> (AlertInfo, Int) -> Event t (AlertInfo, Int) -> m (Dynamic t (AlertInfo, Int), Event t ())
+    alertWidgetD _ v vE = do
+      vD <- holdDyn v vE
+      rD <- widgetHoldDyn $ uncurry alertWidget <$> vD
+      let delE = switch . current $ rD
+      pure (vD, delE)
+
+  resD :: Dynamic t (Map Int (Dynamic t (AlertInfo, Int), Event t ())) <- listWithKeyShallowDiff mempty accumAlertsE alertWidgetD
+  let
+    deletesED :: Dynamic t (Map Int (Event t ()))
+    deletesED = fmap snd <$> resD
+
+    infosD :: Dynamic t (Map Int (AlertInfo, Int))
+    infosD = joinDynThroughMap $ fmap fst <$> resD
+
+    deleteE :: Event t [Int]
+    deleteE = switch . current $ do
+      es <- deletesED
+      pure $ fmap M.keys . mergeMap $ es
+    countD :: Dynamic t Int
+    countD = length <$> deletesED
+  pure ()
+
+logAlerts :: forall t m . MonadFrontBase t m => Event t AlertInfo -> m ()
+logAlerts e = postLog $ ffor e $ \AlertInfo{..} -> LogEntry {
+    logTime = alertTime
+  , logSeverity = alertTypeToSeverity alertType
+  , logMessage = localizedShow English alertMessage
+  , logNameSpace = alertNameSpace
+  }
+  where
+        -- | Posting log message
+    postLog :: MonadFrontBase t m => Event t LogEntry -> m ()
+    postLog e = do
+      (_, fire) <- getLogsTrigger
+      performEvent_ $ ffor e $ liftIO . fire
+
+-- | Widget that displays alert to user. Fires when destruction timeout is passed.
+alertWidget :: MonadFrontBase t m => AlertInfo -> Int -> m (Event t ())
+alertWidget AlertInfo{..} n = do
+  elAttr "div" [
+      ("role" , "alert")
+    , ("class", "alert-popup alert alert-handler col-md-offset-3 col-md-6 col-lg-offset-3 col-lg-6 col-sm-12 " <> alertTypeStyle alertType)
+    , ("style", "margin: 0px; border-radius: 0px; background-color: #ff931e; font-weight: normal; color: #ffffff;")
+    ] $ do
+      when (n > 1) $ badgePrimary $ text $ showt n
+      localizedText alertMessage
+  delay (realToFrac alertTimeout) =<< getPostBuild
+
+-- | Which style to use for specific alert type
+alertTypeStyle :: AlertType -> Text
+alertTypeStyle et = case et of
+  AlertTypeInfo       -> "alert-info"
+  AlertTypePrimary    -> "alert-primary"
+  AlertTypeSecondary  -> "alert-secondary"
+  AlertTypeWarn       -> "alert-warning"
+  AlertTypeSuccess    -> "alert-success"
+  AlertTypeFail       -> "alert-danger"

--- a/wallet/src/Ergvein/Wallet/Main.hs
+++ b/wallet/src/Ergvein/Wallet/Main.hs
@@ -4,7 +4,7 @@ module Ergvein.Wallet.Main(
   ) where
 
 import Data.ByteString (ByteString)
-import Ergvein.Wallet.Alert
+import Ergvein.Wallet.Alert.Handler
 import Ergvein.Wallet.Elements
 import Ergvein.Wallet.Log.Writer
 import Ergvein.Wallet.Monad

--- a/wallet/src/Ergvein/Wallet/Monad/Base.hs
+++ b/wallet/src/Ergvein/Wallet/Monad/Base.hs
@@ -93,10 +93,11 @@ alertTypeToSeverity et = case et of
 -- | All info that is required to draw alert message to user
 data AlertInfo = forall a . (LocalizedPrint a, Eq a) =>  AlertInfo {
   alertType       :: !AlertType -- ^ Style of message
-, alertTimeout    :: !Double -- ^ Amount of seconds the message should be shown
-, alertNameSpace  :: ![Text] -- ^ Optional name space for logs
-, alertTime       :: !UTCTime -- ^ Time of alert
-, alertMessage    :: !a -- ^ Message to display
+, alertTimeout    :: !Double    -- ^ Amount of seconds the message should be shown
+, alertNameSpace  :: ![Text]    -- ^ Optional name space for logs
+, alertTime       :: !UTCTime   -- ^ Time of alert
+, alertDoLog      :: !Bool      -- ^ Whether to log the alert or not
+, alertMessage    :: !a         -- ^ Message to display
 }
 
 -- | Allows to delegate alert displaying to another widget without coupling with it

--- a/wallet/src/Ergvein/Wallet/Monad/Env.hs
+++ b/wallet/src/Ergvein/Wallet/Monad/Env.hs
@@ -166,8 +166,8 @@ liftEnv passE = do
     estore <- flip runReaderT storeDir $ loadStorageFromFile pass
     pure (ts,estore)
   postAlert $ ffor estorageE $ \(ts, estore) -> case estore of
-    Left err -> AlertInfo AlertTypeFail 10 ["Storage"] ts err
-    Right _  -> AlertInfo AlertTypeSuccess 10 ["Storage"] ts SALoadedSucc
+    Left err -> AlertInfo AlertTypeFail 10 ["Storage"] ts True err
+    Right _  -> AlertInfo AlertTypeSuccess 10 ["Storage"] ts True SALoadedSucc
   settings        <- getSettings
   backEF          <- getBackEventFire
   loading         <- getLoadingWidgetTF

--- a/wallet/src/Ergvein/Wallet/Monad/Util.hs
+++ b/wallet/src/Ergvein/Wallet/Monad/Util.hs
@@ -4,13 +4,25 @@ module Ergvein.Wallet.Monad.Util
   , runOnUiThread_
   , runOnUiThreadA
   , runOnUiThreadM
+  , nameSpace
   ) where
 
 import Control.Monad.IO.Class
 import Control.Concurrent
 import Control.Concurrent.Async
+import Ergvein.Wallet.Monad.Base
 import Ergvein.Wallet.Monad.Front
 import Reflex
+import Reflex.ExternalRef
+
+-- | Wrap log name space for given widget
+nameSpace :: MonadFrontBase t m => Text -> m a -> m a
+nameSpace n ma = do
+  ref <- getLogsNameSpacesRef
+  ns <- modifyExternalRef ref $ \ns -> (n:ns, ns)
+  a <- ma
+  writeExternalRef ref ns
+  pure a
 
 -- | Execute the action in main thread of UI. Very useful for android API actions
 -- that must be executed in the same thread where Looper was created.

--- a/wallet/src/Ergvein/Wallet/Page/Initial.hs
+++ b/wallet/src/Ergvein/Wallet/Page/Initial.hs
@@ -2,6 +2,7 @@ module Ergvein.Wallet.Page.Initial(
     initialPage
   ) where
 
+import Ergvein.Wallet.Alert
 import Ergvein.Wallet.Alert.Type
 import Ergvein.Wallet.Elements
 import Ergvein.Wallet.Monad
@@ -10,7 +11,6 @@ import Ergvein.Wallet.Wrapper
 import Ergvein.Wallet.Language
 
 import Control.Monad.IO.Class
-import Data.Time
 import Ergvein.Wallet.Clipboard
 
 data GoPage = GoSeed | GoRestore
@@ -28,14 +28,16 @@ instance LocalizedPrint InitialPageStrings where
       IPSCreate   -> "Создать кошелёк"
       IPSRestore  -> "Восстановить кошелёк"
 
+-- | TODO: remove debugging elements
 initialPage :: MonadFrontBase t m => m ()
 initialPage = wrapper True $ divClass "initial-options" $ do
   newE <- fmap (GoSeed <$) $ row . outlineButton $ IPSCreate
   restoreE <- fmap (GoRestore <$) $ row . outlineButton $ IPSRestore
   let goE = leftmost [newE, restoreE]
   panicE <- row . outlineButton $ ("Span panic" :: Text)
-  panicE' <- performEvent $ (liftIO getCurrentTime) <$ panicE
-  postAlert $ (\now -> AlertInfo AlertTypeFail 10 ["Debug"] now DebugPanicAlert) <$> panicE'
+  panicLogE <- row . outlineButton $ ("Log panic" :: Text)
+  showDangerMsg $ DebugPanicAlert <$ panicE
+  handleDangerMsg $ (Left DebugPanicAlert) <$ panicLogE
   copyButton (pure "Copied this")
   void $ nextWidget $ ffor goE $ \go -> Retractable {
       retractableNext = case go of


### PR DESCRIPTION
Alerts have ``alertDoLog :: Bool`` field, which tells alert handler whether to log the message or not

``alertHandlerWidget`` moved to ``Ergvein.Wallet.Alert.Handler``
``Ergvein.Wallet.Alert`` is now as follows:

It has three groups of functions:
* ``show*Msg :: (Event msg) -> m () ``
    simply sends message to alert popup w/o logging the message
* ``handle*Msg :: Event (Either msg val) -> m (Event val)``
    sends Left occurences to alert popup and passed Right occurences through.
    handle*Msg logs all Left occurences (!)
* ``log*Msg :: Event (Either msg val) -> m (Event val)``
    simply logs the Left occurences w/o sending them to alert popup. Passes Right through
* This module also reexports common alert types and sets defaultMsgTimeout

close #92, close #57 