### PR TITLE
close #101

### DIFF
--- a/wallet/app/Main.hs
+++ b/wallet/app/Main.hs
@@ -27,7 +27,7 @@ instance ParseRecord Options
 main :: IO ()
 main = do
   opts <- getRecord "Ergvein cryptowallet"
-  settings :: Settings <- getSettings $ unHelpful $ config opts
+  settings :: Settings <- loadSettings $ unHelpful $ config opts
   run $ \cbs -> do
     css <- compileFrontendCss
     mainWidgetWithCss css $ do

--- a/wallet/src/Ergvein/Wallet/Monad/Front.hs
+++ b/wallet/src/Ergvein/Wallet/Monad/Front.hs
@@ -32,7 +32,12 @@ type MonadFront t m = (MonadFrontBase t m, MonadStorage t m)
 type AuthInfo = ErgveinStorage
 
 class MonadFrontConstr t m => MonadFrontBase t m | m -> t where
+  -- | Get current settings
   getSettings :: m Settings
+  -- | Update app's settings. Sets settings to provided value and stores them
+  updateSettings :: Event t Settings -> m ()
+  -- | Get settings ref. Internal
+  getSettingsRef :: m (ExternalRef t Settings)
   -- | Get loading widget trigger and fire
   getLoadingWidgetTF :: m (Event t (Text, Bool), (Text, Bool) -> IO ())
   -- | Request displaying the loading widget

--- a/wallet/src/Ergvein/Wallet/Settings.hs
+++ b/wallet/src/Ergvein/Wallet/Settings.hs
@@ -1,42 +1,57 @@
 {-# LANGUAGE CPP #-}
 module Ergvein.Wallet.Settings (
     Settings(..)
-  , getSettings
+  , loadSettings
+  , storeSettings
   ) where
 
 import Control.Lens
 import Control.Monad.IO.Class
 import Data.Default
-import Data.Text(Text, pack)
+import Data.Text(Text, pack, unpack)
 import Data.Yaml (encodeFile)
 import Ergvein.Aeson
 import Ergvein.Lens
 import Ergvein.Wallet.Language
-import Ergvein.Wallet.Yaml(readYaml')
+import Ergvein.Wallet.Yaml(readYamlEither')
 import System.Directory
+
+import qualified Control.Exception   as Exception
+import qualified Data.Text as T
+
 #ifdef ANDROID
 import Android.HaskellActivity
 #endif
 
 data Settings = Settings {
-  settingsLang      :: Language
-, settingsStoreDir  :: Text
+  settingsLang        :: Language
+, settingsStoreDir    :: Text
+, settingsConfigPath  :: Text
 } deriving (Eq, Show)
 
 $(deriveJSON (aesonOptionsStripPrefix "settings") ''Settings)
 
 makeLensesWith humbleFields ''Settings
 
+-- | TODO: Implement some checks to see if the configPath folder is ok to write to
+storeSettings :: MonadIO m => Settings -> m ()
+storeSettings s = liftIO $ do
+  let configPath = settingsConfigPath s
+  createDirectoryIfMissing True $ unpack $ T.dropEnd 1 $ fst $ T.breakOnEnd "/" configPath
+  encodeFile (unpack configPath) s
+
 #ifdef ANDROID
 mkDefSettings :: MonadIO m => FilePath -> m Settings
 mkDefSettings home = liftIO $ do
-  createDirectoryIfMissing True (home <> "/store")
-  let cfg = Settings English (pack home <> "/store")
-  encodeFile (home <> "/config.yaml") cfg
+  let storePath   = home <> "/store"
+      configPath  = home <> "/config.yaml"
+      cfg = Settings English (pack storePath) (pack configPath)
+  createDirectoryIfMissing True storePath
+  encodeFile configPath cfg
   pure cfg
 
-getSettings :: MonadIO m => Maybe FilePath -> m Settings
-getSettings = const $ liftIO $ do
+loadSettings :: MonadIO m => Maybe FilePath -> m Settings
+loadSettings = const $ liftIO $ do
   mpath <- getFilesDir =<< getHaskellActivity
   case mpath of
     Nothing -> fail "Ergvein panic! No local folder!"
@@ -44,7 +59,7 @@ getSettings = const $ liftIO $ do
       ex <- doesFileExist $ path <> "/config.yaml"
       if not ex
         then mkDefSettings path
-        else maybe (mkDefSettings path) pure =<< readYaml' path
+        else either (const $ mkDefSettings path) pure =<< readYamlEither' path
 #else
 mkDefSettings :: MonadIO m => m Settings
 mkDefSettings = liftIO $ do
@@ -53,22 +68,24 @@ mkDefSettings = liftIO $ do
   putStrLn $ "Config path: " <> home <> "/.ergvein/config.yaml"
   putStrLn $ "Store  path: " <> home <> "/.ergvein/store"
   putStrLn $ "Language   : English"
-  createDirectoryIfMissing True (home <> "/.ergvein/store")
-  let cfg = Settings English (pack home <> "/.ergvein/store")
-  encodeFile (home <> "/.ergvein/config.yaml") cfg
+  let storePath   = home <> "/.ergvein/store"
+      configPath  = home <> "/.ergvein/config.yaml"
+      cfg = Settings English (pack storePath) (pack configPath)
+  createDirectoryIfMissing True storePath
+  encodeFile configPath cfg
   pure cfg
 
-getSettings :: MonadIO m => Maybe FilePath -> m Settings
-getSettings mpath = liftIO $ case mpath of
+loadSettings :: MonadIO m => Maybe FilePath -> m Settings
+loadSettings mpath = liftIO $ case mpath of
   Nothing -> do
     home <- getHomeDirectory
     let path = home <> "/.ergvein/config.yaml"
     putStrLn "[ WARNING ]: No path provided. Trying the default: "
     putStrLn path
-    getSettings $ Just path
+    loadSettings $ Just path
   Just path -> do
     ex <- doesFileExist path
     if not ex
       then mkDefSettings
-      else maybe mkDefSettings pure =<< readYaml' path
+      else either (const mkDefSettings) pure =<< readYamlEither' path
 #endif

--- a/wallet/src/Ergvein/Wallet/Yaml.hs
+++ b/wallet/src/Ergvein/Wallet/Yaml.hs
@@ -1,23 +1,33 @@
 module Ergvein.Wallet.Yaml(
     loadYaml
+  , loadYamlEither
   , readYaml
   , readYaml'
+  , readYamlEither'
 ) where
 
 import Data.Aeson
 import Data.ByteString (ByteString)
 import Data.ByteString as BS       (readFile)
-import Data.Yaml                   (decodeEither')
+import Data.Yaml                   (decodeEither', ParseException, prettyPrintParseException)
 import Data.Yaml.Config            (loadYamlSettings, useEnv)
 import qualified Control.Exception   as Exception
+import qualified Data.Text           as T
 
 loadYaml ::  FromJSON settings => ByteString -> IO settings
 loadYaml bs = loadYamlSettings [] [value] useEnv
   where
     value = either Exception.throw id $ decodeEither' bs
 
+loadYamlEither ::  FromJSON settings => ByteString -> IO (Either T.Text settings)
+loadYamlEither bs = Exception.catch (fmap Right $ loadYaml bs)
+  (\(ex :: Exception.SomeException) -> pure $ Left $ T.pack $ show ex)
+
 readYaml' :: FromJSON settings => FilePath -> IO settings
 readYaml' fp = loadYaml =<< BS.readFile fp
+
+readYamlEither' :: FromJSON settings => FilePath -> IO (Either T.Text settings)
+readYamlEither' fp = loadYamlEither =<< BS.readFile fp
 
 readYaml :: FromJSON settings => FilePath -> IO settings
 readYaml fp = loadYamlSettings [fp] [] useEnv


### PR DESCRIPTION
* ``Settings`` in ``Env``/``UnauthEnv`` are now stored in ``ExternalRef``.
* ``getSettings`` from ``Ergvein.Wallet.Settings`` renamed to ``loadSettings`` to avoid collisions
* ``storeSettings`` implemented
* ``updateSettings`` is available throughout ``MonadFrontBase``
* If settings file is corrupt or outdated (misses keys) — default settings are used instead