### PR TITLE
Trigger travis builds only on master branch and PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,7 @@ script:
 - nix-build -A ghc.ergvein-index-server
 - nix-build --arg isAndroid true -A android.ergvein-wallet
 - cd nix && ./ci-build-docker.sh
+
+branches:
+  only:
+  - master


### PR DESCRIPTION
On pull requests we have double builds now. One is for push branch and another one is for PR.