### PR TITLE
Unencrypted wallet

### DIFF
--- a/wallet-types/src/Ergvein/Types/AuthInfo.hs
+++ b/wallet-types/src/Ergvein/Types/AuthInfo.hs
@@ -13,6 +13,8 @@ data AuthInfo = AuthInfo {
   -- ^ This field indicates whether the widget should be redrawn in 'liftAuth'.
   -- 'False' means that the value obtained as a result of updating the previous 'AuthInfo',
   -- 'True' means that the value was newly created or loaded from the storage file at startup.
+, _authInfo'isPlain     :: Bool
+  -- ^ this field indicates if the storage is encrypted with empty string, aka not encrypted
 } deriving (Eq)
 
 makeLenses ''AuthInfo

--- a/wallet/src/Ergvein/Wallet/Localization/Password.hs
+++ b/wallet/src/Ergvein/Wallet/Localization/Password.hs
@@ -4,6 +4,7 @@ module Ergvein.Wallet.Localization.Password
   , PasswordWidgetStrings(..)
   , LoginPageStrings(..)
   , PatternPageStrings(..)
+  , ConfirmEmptyPage(..)
   ) where
 
 import Data.Text (Text)
@@ -86,3 +87,16 @@ instance LocalizedPrint PasswordWidgetStrings where
       PWSDeriv         -> "Префикс BIP48 для вывода ключей"
       PWSDerivDescr    -> "Вы можете переназначить префикс дерева для вывода ключей. Оставьте как есть, если не знаете, что это такое."
       PWSInvalidPath   -> "Путь вывода неверен! Формат поля m/0'/0'/0'"
+
+data ConfirmEmptyPage = CEPBack | CEPAttention | CEPConsequences
+
+instance LocalizedPrint ConfirmEmptyPage where
+  localizedShow l v = case l of
+    English -> case v of
+      CEPBack         -> "Back"
+      CEPAttention    -> "The password is empty. Are you sure?"
+      CEPConsequences -> "The wallet will be accesible without password"
+    Russian -> case v of
+      CEPBack         -> "Назад"
+      CEPAttention    -> "Пустой пароль. Вы уверены?"
+      CEPConsequences -> "Кошелёк будет доступен без ввода пароля"

--- a/wallet/src/Ergvein/Wallet/Page/Currencies.hs
+++ b/wallet/src/Ergvein/Wallet/Page/Currencies.hs
@@ -28,7 +28,7 @@ selectCurrenciesPage wt mnemonic = wrapperSimple True $ do
 #ifdef ANDROID
       retractableNext = setupLoginPage wt Nothing mnemonic ac
 #else
-      retractableNext = passwordPage wt Nothing mnemonic ac
+      retractableNext = passwordPage wt Nothing mnemonic ac Nothing
 #endif
     -- , retractablePrev = Just $ pure $ selectCurrenciesPage wt mnemonic -- TODO: uncomment this when ERGO is ready
     , retractablePrev = Nothing -- TODO: remove this when ERGO is ready

--- a/wallet/src/Ergvein/Wallet/Password.hs
+++ b/wallet/src/Ergvein/Wallet/Password.hs
@@ -50,9 +50,9 @@ setupPassword e = divClass "setup-password" $ form $ fieldset $ mdo
     check PWSNoMatch $ p1 == p2
     pure p1
 
-setupLoginPassword :: MonadFrontBase t m => Event t () -> m (Event t (Text, Password))
-setupLoginPassword e = divClass "setup-password" $ form $ fieldset $ mdo
-  loginD <- textFieldAttr PWSLogin ("placeholder" =: "my wallet name") ""
+setupLoginPassword :: MonadFrontBase t m => Maybe Text -> Event t () -> m (Event t (Text, Password))
+setupLoginPassword mlogin e = divClass "setup-password" $ form $ fieldset $ mdo
+  loginD <- textFieldAttr PWSLogin ("placeholder" =: "my wallet name") $ fromMaybe "" mlogin
   p1D <- passFieldWithEye PWSPassword
   p2D <- passFieldWithEye PWSRepeat
   validate $ poke e $ const $ runExceptT $ do

--- a/wallet/src/Ergvein/Wallet/Storage/AuthInfo.hs
+++ b/wallet/src/Ergvein/Wallet/Storage/AuthInfo.hs
@@ -27,6 +27,7 @@ initAuthInfo wt mpath mnemonic curs login pass = do
         , _authInfo'eciesPubKey = toPublic k
         , _authInfo'login = login
         , _authInfo'isUpdate = False
+        , _authInfo'isPlain = pass == ""
         }
 
 loadAuthInfo :: (MonadIO m, HasStoreDir m, PlatformNatives) => WalletName -> Password -> m (Either AuthInfoAlert (AuthInfo, Password))
@@ -42,6 +43,7 @@ loadAuthInfo login pass = do
           , _authInfo'eciesPubKey = toPublic k
           , _authInfo'login = login
           , _authInfo'isUpdate = False
+          , _authInfo'isPlain = pass == ""
           }
         , pass
         )


### PR DESCRIPTION
Treat a wallet with empty password as unencrypted

* Encrypt with empty password
* Try to decode public storage with empty password. If successful, treat the wallet as unencrypted
* Store a flag in env, indicating that the password is empty
* If the flag is set, decode private storage with empty password, instead of requesting a password

close #701