### PR TITLE
Mobile password

### DIFF
--- a/wallet/src/Ergvein/Wallet/Localization/Password.hs
+++ b/wallet/src/Ergvein/Wallet/Localization/Password.hs
@@ -22,24 +22,33 @@ instance LocalizedPrint LoginPageStrings where
       LPSTitle  -> "Установите логин для кошелька"
       LPSDescr -> "Вы можете иметь несколько кошельков и имя поможет различать их"
 
-data PatternPageStrings = PatPSTitle | PatPSDescr
+data PatternPageStrings = PatPSTitle | PatPSDescr | PatPSPass | PatPSPatt | PatPSUsePass | PatPSUsePattern
 
 instance LocalizedPrint PatternPageStrings where
   localizedShow l v = case l of
     English -> case v of
-      PatPSTitle -> "Setup encryption pattern key for your wallet"
-      PatPSDescr -> "The pattern key is used every time you perform an operation with your money"
+      PatPSTitle      -> "Setup encryption pattern key for your wallet"
+      PatPSDescr      -> "The pattern key is used every time you perform an operation with your money"
+      PatPSPass       -> "Set password"
+      PatPSPatt       -> "Set pattern"
+      PatPSUsePass    -> "Use password"
+      PatPSUsePattern -> "Use pattern"
     Russian -> case v of
-      PatPSTitle -> "Установите графический ключ шифрования для кошелька"
-      PatPSDescr -> "Этот графический ключ используется для каждой операции с вашими деньгами"
+      PatPSTitle      -> "Установите графический ключ шифрования для кошелька"
+      PatPSDescr      -> "Этот графический ключ используется для каждой операции с вашими деньгами"
+      PatPSPass       -> "Установить пароль"
+      PatPSPatt       -> "Установить ключ"
+      PatPSUsePass    -> "Ввести пароль"
+      PatPSUsePattern -> "Ввести ключ"
 
-data PasswordPageStrings = PPSTitle | PPSDescr | PPSMnemonicTitle | PPSMnemonicDescr | PPSUnlock | PPSMnemonicUnlock | PPSWrongPassword
+data PasswordPageStrings = PPSTitle | PPSPassTitle | PPSDescr | PPSMnemonicTitle | PPSMnemonicDescr | PPSUnlock | PPSMnemonicUnlock | PPSWrongPassword
   deriving (Eq)
 
 instance LocalizedPrint PasswordPageStrings where
   localizedShow l v = case l of
     English -> case v of
       PPSTitle          -> "Setup login and encryption password for your wallet"
+      PPSPassTitle      -> "Setup encryption password for your wallet"
       PPSDescr          -> "The password is used every time you perform an operation with your money. Leave the password fields empty to set no password for your wallet (not recommended)."
       PPSMnemonicTitle  -> "Setup encryption password for your mnemonic phrase"
       PPSMnemonicDescr  -> "We ask you to set a separate password for compatibility between mobile and desktop versions of the application. Leave the fields empty to set no password for your mnemonic phrase (not recommended)."
@@ -48,6 +57,7 @@ instance LocalizedPrint PasswordPageStrings where
       PPSWrongPassword  -> "Wrong password"
     Russian -> case v of
       PPSTitle          -> "Установите логин и пароль для шифрования кошелька"
+      PPSPassTitle      -> "Установите пароль для шифрования кошелька"
       PPSDescr          -> "Этот пароль используется для каждой операции с вашими деньгами. Можете оставить поля пароля пустыми, если хотите (не рекомендуется)."
       PPSMnemonicTitle  -> "Установите пароль для шифрования мнемонической фразы"
       PPSMnemonicDescr  -> "Мы просим Вас установить отдельный пароль для совместимости между мобильной и десктопной версией приложения. Можете оставить поля пустыми, если хотите (не рекомендуется)."

--- a/wallet/src/Ergvein/Wallet/Page/Initial.hs
+++ b/wallet/src/Ergvein/Wallet/Page/Initial.hs
@@ -3,6 +3,7 @@ module Ergvein.Wallet.Page.Initial(
     initialPage
   ) where
 
+import Data.Either (fromRight)
 import Ergvein.Types.Storage
 import Ergvein.Wallet.Alert
 import Ergvein.Wallet.Elements
@@ -98,6 +99,7 @@ loadWalletPage name = do
     Right _ -> pure never
     Left _ -> do
       passE <- askPasswordPage name
+      isPass <- fmap (either (const False) id) $ retrieveValue ("meta_wallet_" <> name) False
       mOldAuthE <- performEvent $ loadAuthInfo name <$> passE
       handleDangerMsg mOldAuthE
   let oldAuthE = leftmost [oldAuthE', oldAuthE'']

--- a/wallet/src/Ergvein/Wallet/Page/Password.hs
+++ b/wallet/src/Ergvein/Wallet/Page/Password.hs
@@ -37,29 +37,45 @@ passwordPage wt mpath mnemonic curs mlogin = wrapperSimple True $ do
   let goE = current pathD `attach` logPassE
   void $ nextWidget $ ffor goE $ \(path, (login,pass)) -> Retractable {
       retractableNext = if pass == ""
-        then confirmEmptyPage wt mnemonic curs login pass $ Just path
-        else performAuth wt mnemonic curs login pass (Just path)
+        then confirmEmptyPage wt mnemonic curs login pass (Just path) True
+        else performAuth wt mnemonic curs login pass (Just path) True
     , retractablePrev = if pass == ""
         then Just $ pure $ passwordPage wt (Just path) mnemonic curs (Just login)
         else Nothing
     }
 
-confirmEmptyPage :: MonadFrontBase t m => WalletSource -> Mnemonic -> [Currency] -> Text -> Password -> Maybe DerivPrefix -> m ()
-confirmEmptyPage wt mnemonic curs login pass mpath = wrapperSimple True $ do
+confirmEmptyPage :: MonadFrontBase t m
+  => WalletSource
+  -> Mnemonic
+  -> [Currency]
+  -> Text
+  -> Password
+  -> Maybe DerivPrefix
+  -> Bool
+  -> m ()
+confirmEmptyPage wt mnemonic curs login pass mpath isPass = wrapperSimple True $ do
   h4 $ localizedText CEPAttention
   h5 $ localizedText CEPConsequences
   divClass "fit-content ml-a mr-a" $ do
     setE <- divClass "" (submitClass "button button-outline w-100" PWSSet)
     retract =<< divClass "" (submitClass "button button-outline w-100" CEPBack)
     void $ nextWidget $ ffor setE $ const $ Retractable {
-        retractableNext = performAuth wt mnemonic curs login pass mpath
+        retractableNext = performAuth wt mnemonic curs login pass mpath isPass
       , retractablePrev = Nothing
       }
 
-performAuth :: MonadFrontBase t m => WalletSource -> Mnemonic -> [Currency] -> Text -> Password -> Maybe DerivPrefix -> m ()
-performAuth wt mnemonic curs login pass mpath = do
+performAuth :: MonadFrontBase t m
+  => WalletSource
+  -> Mnemonic
+  -> [Currency]
+  -> Text
+  -> Password
+  -> Maybe DerivPrefix
+  -> Bool
+  -> m ()
+performAuth wt mnemonic curs login pass mpath isPass = do
   buildE <- getPostBuild
-  storage <- initAuthInfo wt mpath mnemonic curs login pass
+  storage <- initAuthInfo wt mpath mnemonic curs login pass isPass
   authInfoE <- handleDangerMsg $ storage <$ buildE
   void $ setAuthInfo $ Just <$> authInfoE
 
@@ -78,17 +94,43 @@ setupLoginPage wt mpath mnemonic curs = wrapperSimple True $ do
 
 setupPatternPage :: MonadFrontBase t m => WalletSource -> Maybe DerivPrefix -> Mnemonic -> Text -> [Currency] -> m ()
 setupPatternPage wt mpath mnemonic l curs = wrapperSimple True $ do
+  let this = Just $ pure $ setupPatternPage wt mpath mnemonic l curs
   divClass "password-setup-title" $ h4 $ localizedText PatPSTitle
   divClass "password-setup-descr" $ h5 $ localizedText PatPSDescr
   patE <- setupPattern
-  skipE <- divClass "" $ submitClass "button button-outline" CEPSkip
+  (setPassE, skipE) <- divClass "fit-content ml-a mr-a" $ do
+    setPassE <- divClass "" $ submitClass "button button-outline w-100" PatPSPass
+    skipE <- divClass "" $ submitClass "button button-outline w-100" CEPSkip
+    pure (setPassE, skipE)
   let passE = leftmost ["" <$ skipE, patE]
   void $ nextWidget $ ffor passE $ \pass -> Retractable {
       retractableNext = if pass == ""
-        then confirmEmptyPage wt mnemonic curs l pass mpath
-        else performAuth wt mnemonic curs l pass mpath
+        then confirmEmptyPage wt mnemonic curs l pass mpath False
+        else performAuth wt mnemonic curs l pass mpath False
+    , retractablePrev = if pass == "" then this else Nothing
+    }
+  void $ nextWidget $ ffor setPassE $ const $ Retractable {
+      retractableNext = setupMobilePasswordPage wt mpath mnemonic l curs
+    , retractablePrev = this
+    }
+
+setupMobilePasswordPage :: MonadFrontBase t m => WalletSource -> Maybe DerivPrefix -> Mnemonic -> Text -> [Currency] -> m ()
+setupMobilePasswordPage wt mpath mnemonic l curs = wrapperSimple True $ do
+  divClass "password-setup-title" $ h4 $ localizedText PPSPassTitle
+  divClass "password-setup-descr" $ h5 $ localizedText PPSDescr
+  rec
+    passE <- setupPassword btnE
+    btnE <- divClass "fit-content ml-a mr-a" $ do
+      btnE <- divClass "" $ (submitClass "button button-outline w-100" PWSSet)
+      setPattE <- divClass "" $ submitClass "button button-outline w-100" PatPSPatt
+      retract setPattE
+      pure btnE
+  void $ nextWidget $ ffor passE $ \pass -> Retractable {
+      retractableNext = if pass == ""
+        then confirmEmptyPage wt mnemonic curs l pass mpath True
+        else performAuth wt mnemonic curs l pass mpath True
     , retractablePrev = if pass == ""
-        then Just $ pure $ setupPatternPage wt mpath mnemonic l curs
+        then Just $ pure $ setupMobilePasswordPage wt mpath mnemonic l curs
         else Nothing
     }
 

--- a/wallet/src/Ergvein/Wallet/Password.hs
+++ b/wallet/src/Ergvein/Wallet/Password.hs
@@ -13,6 +13,7 @@ module Ergvein.Wallet.Password(
 
 import Control.Monad.Except
 import Data.Maybe
+import Data.Either (fromRight)
 import Ergvein.Crypto
 import Ergvein.Text
 import Ergvein.Types
@@ -33,6 +34,7 @@ import Control.Monad.IO.Class
 import Data.Time (getCurrentTime)
 import Ergvein.Text
 import Ergvein.Wallet.Localization.PatternKey
+import Ergvein.Wallet.Native
 import Ergvein.Wallet.Storage.Util
 import qualified Data.Map.Strict as Map
 #endif
@@ -81,10 +83,35 @@ askTextPassword title description = do
 #ifdef ANDROID
 
 askPassword :: MonadFrontBase t m => Text -> m (Event t Password)
-askPassword name = do
+askPassword name = mdo
+  let fpath = "meta_wallet_" <> name
+  isPass0 <- fmap (fromRight False) $ retrieveValue fpath False
+  isPassD <- holdDyn isPass0 tglE
+  valD <- widgetHoldDyn $ ffor isPassD $ \isPass -> if isPass
+    then askPasswordImpl name
+    else askPatternImpl name
+  let (passE, tglE) = (\(a,b) -> (switchDyn a, switchDyn b)) $ splitDynPure valD
+  pure passE
+
+askPasswordImpl :: MonadFrontBase t m => Text -> m (Event t Password, Event t Bool)
+askPasswordImpl name = do
+  let fpath = "meta_wallet_" <> name
+  storeValue fpath True True
+  divClass "password-ask-title" $ h4 $ localizedText PPSUnlock
+  divClass "ask-password" $ form $ fieldset $ do
+    pD <- passFieldWithEye $ PWSPassNamed name
+    divClass "fit-content ml-a mr-a" $ do
+      e <- divClass "" $ submitClass "button button-outline w-100" PWSGo
+      patE <- divClass "" $ submitClass "button button-outline w-100" PatPSUsePattern
+      pure $ (tag (current pD) e, False <$ patE)
+
+askPatternImpl :: MonadFrontBase t m => Text -> m (Event t Password, Event t Bool)
+askPatternImpl name = do
+  let fpath = "meta_wallet_" <> name
+  storeValue fpath False True
   divClass "password-ask-title" $ h5 $ localizedText PKSUnlock
   divClass "password-ask-title" $ h5 $ localizedText $ PKSFor name
-  divClass "ask-pattern" $ form $ fieldset $ mdo
+  patE <- divClass "ask-pattern" $ form $ fieldset $ mdo
     c <- loadCounter
     let cInt = case (Map.lookup name (patterntriesCount c)) of
           Just p -> p
@@ -113,6 +140,8 @@ askPassword name = do
       liftIO $ saveCounter $ PatternTries $ Map.insert name cS (patterntriesCount c)
       pure ()
     pure $ attachPromptlyDynWithMaybe (\freeze p -> if not freeze then Just p else Nothing) freezeD (updated pD)
+  passE <- submitClass "button button-outline" PatPSUsePass
+  pure (patE, True <$ passE)
 
 askPasswordModal :: MonadFrontBase t m => m ()
 askPasswordModal = mdo
@@ -122,8 +151,7 @@ askPasswordModal = mdo
   valD <- widgetHold (pure (never, never)) $ ffor redrawE $ \case
     Just (i, name) -> divClass "ask-pattern-modal" $ do
       closeE <- passwordHeader
-      passE <- divClass "mt-1" $ do
-        h4 $ localizedText PKSAsk
+      passE <- divClass "mt-1 ml-1 mr-1" $ do
         askPassword name
       let passE' = fmap ((i,) . Just) passE
       pure (passE', closeE)

--- a/wallet/src/Ergvein/Wallet/Storage/AuthInfo.hs
+++ b/wallet/src/Ergvein/Wallet/Storage/AuthInfo.hs
@@ -13,10 +13,23 @@ import Ergvein.Wallet.Elements.Input
 import Ergvein.Wallet.Localization.AuthInfo
 import Ergvein.Wallet.Monad
 import Ergvein.Wallet.Native
+import Ergvein.Wallet.Platform
 import Ergvein.Wallet.Storage.Util
 
-initAuthInfo :: MonadIO m => WalletSource -> Maybe DerivPrefix -> Mnemonic -> [Currency] -> WalletName -> Password -> m (Either AuthInfoAlert AuthInfo)
-initAuthInfo wt mpath mnemonic curs login pass = do
+import qualified Data.Text as T
+
+initAuthInfo :: (MonadIO m, PlatformNatives, HasStoreDir m)
+  => WalletSource
+  -> Maybe DerivPrefix
+  -> Mnemonic
+  -> [Currency]
+  -> WalletName
+  -> Password
+  -> Bool
+  -> m (Either AuthInfoAlert AuthInfo)
+initAuthInfo wt mpath mnemonic curs login pass isPass = do
+  let fname = "meta_wallet_" <> (T.replace " " "_" login)
+  when (isAndroid && isPass) $ storeValue ("meta_wallet_" <> login) True True
   mstorage <- createStorage (wt == WalletRestored) mpath mnemonic (login, pass) curs
   case mstorage of
     Left err -> pure $ Left $ CreateStorageAlert err
@@ -30,7 +43,10 @@ initAuthInfo wt mpath mnemonic curs login pass = do
         , _authInfo'isPlain = pass == ""
         }
 
-loadAuthInfo :: (MonadIO m, HasStoreDir m, PlatformNatives) => WalletName -> Password -> m (Either AuthInfoAlert (AuthInfo, Password))
+loadAuthInfo :: (MonadIO m, HasStoreDir m, PlatformNatives)
+  => WalletName
+  -> Password
+  -> m (Either AuthInfoAlert (AuthInfo, Password))
 loadAuthInfo login pass = do
   mstorage <- loadStorageFromFile login pass
   case mstorage of


### PR DESCRIPTION
Enable password protection option for mobile wallets

At the "Set pattern lock" screen there is a button to switch to password protection.

The choice is stored as a boolean in plain text in a file ``"meta_wallet_" <> walletName``

If something goes wrong with the meta file it is always possible to switch between password and pattern locks 

close #730