### PR TITLE
Add -Wall to ergvien-wallet-types

### DIFF
--- a/wallet-types/ergvein-wallet-types.cabal
+++ b/wallet-types/ergvein-wallet-types.cabal
@@ -12,6 +12,7 @@ flag testnet
   manual: True
 
 library
+  Ghc-options:         -Wall
   hs-source-dirs:      src
   exposed-modules:
     Ergvein.Types

--- a/wallet-types/ergvein-wallet-types.cabal
+++ b/wallet-types/ergvein-wallet-types.cabal
@@ -23,6 +23,7 @@ library
     Ergvein.Types.Fees
     Ergvein.Types.Keys
     Ergvein.Types.Network
+    Ergvein.Types.Orphanage
     Ergvein.Types.Restore
     Ergvein.Types.Storage
     Ergvein.Types.Transaction

--- a/wallet-types/src/Ergvein/Types/Address.hs
+++ b/wallet-types/src/Ergvein/Types/Address.hs
@@ -1,5 +1,5 @@
 module Ergvein.Types.Address (
-      BtcAddress(..)
+      BtcAddress
     , ErgAddress(..)
     , EgvAddress(..)
     , VLAddr(..)
@@ -140,11 +140,11 @@ egvAddrFromJSON cur
       Just x  -> return $ ErgAddress x
 
 instance ToJSON EgvAddress where
-  toJSON egvAddr@(BtcAddress addr) = object [
+  toJSON egvAddr@(BtcAddress _) = object [
       "currency" .= toJSON BTC
     , "address"  .= egvAddrToJSON egvAddr
     ]
-  toJSON egvAddr@(ErgAddress addr) = object [
+  toJSON egvAddr@(ErgAddress _) = object [
       "currency" .= toJSON ERGO
     , "address"  .= egvAddrToJSON egvAddr
     ]

--- a/wallet-types/src/Ergvein/Types/Address.hs
+++ b/wallet-types/src/Ergvein/Types/Address.hs
@@ -30,7 +30,6 @@ import qualified Data.Serialize            as S
 import qualified Data.Serialize.Get        as Get
 import qualified Data.Serialize.Put        as Put
 import qualified Network.Haskoin.Address   as HA
-import qualified Network.Haskoin.Constants as HC
 import qualified Text.Read                 as R
 
 type BtcAddress = HA.Address

--- a/wallet-types/src/Ergvein/Types/Address.hs
+++ b/wallet-types/src/Ergvein/Types/Address.hs
@@ -129,12 +129,12 @@ egvAddrToJSON :: EgvAddress -> Value
 egvAddrToJSON = String . egvAddrToString
 
 egvAddrFromJSON :: Currency -> Value -> Parser EgvAddress
-egvAddrFromJSON cur
-  | cur == BTC = withText "address" $ \t ->
+egvAddrFromJSON = \case
+  BTC -> withText "address" $ \t ->
     case btcAddrFromString t of
       Nothing -> fail "could not decode address"
       Just x  -> return $ BtcAddress x
-  | cur == ERGO = withText "address" $ \t ->
+  ERGO -> withText "address" $ \t ->
     case ergAddrFromString t of
       Nothing -> fail "could not decode address"
       Just x  -> return $ ErgAddress x

--- a/wallet-types/src/Ergvein/Types/Currency.hs
+++ b/wallet-types/src/Ergvein/Types/Currency.hs
@@ -40,11 +40,9 @@ import Data.Flat
 import Data.Maybe (fromMaybe)
 import Data.Ratio
 import Data.Serialize (Serialize)
-import Data.String
-import Data.Text (Text, pack, unpack)
+import Data.Text (Text)
 import Data.Time
 import Data.Time.Clock.POSIX
-import Data.Version
 import Data.Word
 import Ergvein.Aeson
 import Text.Printf

--- a/wallet-types/src/Ergvein/Types/Currency.hs
+++ b/wallet-types/src/Ergvein/Types/Currency.hs
@@ -190,8 +190,8 @@ currencyGenesisTime c = case c of
 -- | Average duration between blocks
 currencyBlockDuration :: Currency -> NominalDiffTime
 currencyBlockDuration c = case c of
-  BTC -> fromIntegral 600
-  ERGO -> fromIntegral 120
+  BTC  -> 600
+  ERGO -> 120
 
 -- | Approx time of block
 currencyBlockTime :: Currency -> Int -> UTCTime
@@ -223,13 +223,13 @@ moneyToRationalUnit (Money cur amount) units = fromIntegral amount % (10 ^ curre
 moneyFromRational :: Currency -> Rational -> Money
 moneyFromRational cur amount = Money cur val
   where
-    val = fromIntegral . round $ amount * (10 ^ currencyResolution cur)
+    val = round $ amount * (10 ^ currencyResolution cur)
 {-# INLINE moneyFromRational #-}
 
 moneyFromRationalUnit :: Currency -> Units-> Rational -> Money
 moneyFromRationalUnit cur units amount = Money cur val
   where
-    val = fromIntegral . round $ amount * (10 ^ currencyResolutionUnit cur units)
+    val = round $ amount * (10 ^ currencyResolutionUnit cur units)
 {-# INLINE moneyFromRationalUnit #-}
 
 -- | Print amount of cryptocurrency

--- a/wallet-types/src/Ergvein/Types/Derive.hs
+++ b/wallet-types/src/Ergvein/Types/Derive.hs
@@ -17,13 +17,11 @@ import Data.Maybe
 import Data.Text (Text)
 import Ergvein.Crypto
 import Ergvein.Text
-import Ergvein.Types.Address
 import Ergvein.Types.Currency
 import Ergvein.Types.Keys
 import Ergvein.Types.Network
 import Text.Read (readMaybe)
 
-import qualified Data.ByteString       as BS
 import qualified Data.Text             as T
 
 -- | Shorthand for encoded BIP48 derivation path like m/84'/0'/0' (hard)

--- a/wallet-types/src/Ergvein/Types/Keys.hs
+++ b/wallet-types/src/Ergvein/Types/Keys.hs
@@ -127,25 +127,25 @@ putXPubKey (EgvErgNetwork net) k = do
 
 -- | Exports an extended private key to the BIP32 key export format ('Base58').
 xPrvExport :: EgvNetwork -> XPrvKey -> Base58
-xPrvExport n@(EgvBtcNetwork net) = encodeBase58CheckBtc . runPut . putXPrvKey n
-xPrvExport n@(EgvErgNetwork net) = encodeBase58CheckErg . runPut . putXPrvKey n
+xPrvExport n@(EgvBtcNetwork _) = encodeBase58CheckBtc . runPut . putXPrvKey n
+xPrvExport n@(EgvErgNetwork _) = encodeBase58CheckErg . runPut . putXPrvKey n
 
 -- | Exports an extended public key to the BIP32 key export format ('Base58').
 xPubExport :: EgvNetwork -> XPubKey -> Base58
-xPubExport n@(EgvBtcNetwork net) = encodeBase58CheckBtc . runPut . putXPubKey n
-xPubExport n@(EgvErgNetwork net) = encodeBase58CheckErg . runPut . putXPubKey n
+xPubExport n@(EgvBtcNetwork _) = encodeBase58CheckBtc . runPut . putXPubKey n
+xPubExport n@(EgvErgNetwork _) = encodeBase58CheckErg . runPut . putXPubKey n
 
 -- | Decodes a BIP32 encoded extended private key. This function will fail if
 -- invalid base 58 characters are detected or if the checksum fails.
 xPrvImport :: EgvNetwork -> Base58 -> Maybe XPrvKey
-xPrvImport n@(EgvBtcNetwork net) = eitherToMaybe . runGet (getXPrvKey n) <=< decodeBase58CheckBtc
-xPrvImport n@(EgvErgNetwork net) = eitherToMaybe . runGet (getXPrvKey n) <=< decodeBase58CheckErg
+xPrvImport n@(EgvBtcNetwork _) = eitherToMaybe . runGet (getXPrvKey n) <=< decodeBase58CheckBtc
+xPrvImport n@(EgvErgNetwork _) = eitherToMaybe . runGet (getXPrvKey n) <=< decodeBase58CheckErg
 
 -- | Decodes a BIP32 encoded extended public key. This function will fail if
 -- invalid base 58 characters are detected or if the checksum fails.
 xPubImport :: EgvNetwork -> Base58 -> Maybe XPubKey
-xPubImport n@(EgvBtcNetwork net) = eitherToMaybe . runGet (getXPubKey n) <=< decodeBase58CheckBtc
-xPubImport n@(EgvErgNetwork net) = eitherToMaybe . runGet (getXPubKey n) <=< decodeBase58CheckErg
+xPubImport n@(EgvBtcNetwork _) = eitherToMaybe . runGet (getXPubKey n) <=< decodeBase58CheckBtc
+xPubImport n@(EgvErgNetwork _) = eitherToMaybe . runGet (getXPubKey n) <=< decodeBase58CheckErg
 
 -- | Wrapper for a root extended private key (a key without assigned network)
 newtype EgvRootXPrvKey = EgvRootXPrvKey {unEgvRootXPrvKey :: XPrvKey}
@@ -289,10 +289,10 @@ instance Ord EgvXPubKey where
     EQ -> compare (xPubExport (getCurrencyNetwork c1) k1) (xPubExport (getCurrencyNetwork c2) k2)
     x -> x
     where
-      (c1, k1, l1) =  case key1 of
+      (c1, k1, _l1) =  case key1 of
         ErgXPubKey k l -> (ERGO, k, l)
         BtcXPubKey k l -> (BTC, k, l)
-      (c2, k2, l2) =  case key2 of
+      (c2, k2, _l2) =  case key2 of
         ErgXPubKey k l -> (ERGO, k, l)
         BtcXPubKey k l -> (BTC, k, l)
 

--- a/wallet-types/src/Ergvein/Types/Keys.hs
+++ b/wallet-types/src/Ergvein/Types/Keys.hs
@@ -44,7 +44,6 @@ import Ergvein.Types.Network
 import Ergvein.Types.Transaction
 import Text.Read              (readMaybe)
 
-import qualified Data.IntMap.Strict as MI
 import qualified Data.Set as S
 import qualified Data.Vector as V
 import qualified Data.ByteString.Short as BSS

--- a/wallet-types/src/Ergvein/Types/Keys.hs
+++ b/wallet-types/src/Ergvein/Types/Keys.hs
@@ -335,9 +335,9 @@ data PubKeystore = PubKeystore {
 $(deriveJSON aesonOptionsStripToApostroph ''PubKeystore)
 
 getLastUnusedKey :: KeyPurpose -> PubKeystore -> Maybe (Int, EgvPubKeyBox)
-getLastUnusedKey kp PubKeystore{..} = go Nothing vec
+getLastUnusedKey kp PubKeystore{..} = go Nothing vector
   where
-    vec = case kp of
+    vector = case kp of
       Internal -> pubKeystore'internal
       External -> pubKeystore'external
     go :: Maybe (Int, EgvPubKeyBox) -> Vector EgvPubKeyBox -> Maybe (Int, EgvPubKeyBox)

--- a/wallet-types/src/Ergvein/Types/Network.hs
+++ b/wallet-types/src/Ergvein/Types/Network.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE CPP #-}
 
 module Ergvein.Types.Network (
-    BtcNetwork(..)
+    BtcNetwork
   , Network(..)
   , ErgNetwork(..)
   , EgvNetwork(..)

--- a/wallet-types/src/Ergvein/Types/Orphanage.hs
+++ b/wallet-types/src/Ergvein/Types/Orphanage.hs
@@ -1,0 +1,25 @@
+-- |
+{-# OPTIONS_GHC -Wno-orphans #-}
+module Ergvein.Types.Orphanage where
+
+import Data.Aeson
+import Data.ByteString.Short (ShortByteString)
+import qualified Data.ByteString.Short   as BSS
+import Network.Haskoin.Transaction (OutPoint)
+import Network.Haskoin.Block (BlockHash)
+import Ergvein.Text
+
+instance FromJSONKey BlockHash
+instance ToJSONKey   BlockHash
+
+instance FromJSONKey OutPoint
+instance ToJSONKey   OutPoint
+
+instance FromJSON ShortByteString where
+  parseJSON = withText "ShortByteString" $
+    either (fail "Failed to parse a ShortByteString") (pure . BSS.toShort) . hex2bsTE
+  {-# INLINE parseJSON #-}
+
+instance ToJSON ShortByteString where
+  toJSON = String . bs2Hex . BSS.fromShort
+  {-# INLINE toJSON #-}

--- a/wallet-types/src/Ergvein/Types/Storage.hs
+++ b/wallet-types/src/Ergvein/Types/Storage.hs
@@ -24,6 +24,7 @@ import Ergvein.Types.Derive
 import Ergvein.Types.Keys
 import Ergvein.Types.Transaction
 import Ergvein.Types.Utxo
+import Ergvein.Types.Orphanage ()
 
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
@@ -108,9 +109,6 @@ data CurrencyPubStorage = CurrencyPubStorage {
 makeLenses ''CurrencyPubStorage
 
 $(deriveJSON aesonOptionsStripToApostroph ''CurrencyPubStorage)
-
-instance FromJSONKey HB.BlockHash where
-instance ToJSONKey HB.BlockHash where
 
 type CurrencyPubStorages = M.Map Currency CurrencyPubStorage
 

--- a/wallet-types/src/Ergvein/Types/Transaction.hs
+++ b/wallet-types/src/Ergvein/Types/Transaction.hs
@@ -89,7 +89,7 @@ egvTxToString (ErgTx tx _) = ergTxToString tx
 
 egvTxId :: EgvTx -> TxId
 egvTxId (BtcTx tx _) = hkTxHashToEgv $ HK.txHash tx
-egvTxId (ErgTx tx _) = error "egvTxId: implement for Ergo!"
+egvTxId (ErgTx _  _) = error "egvTxId: implement for Ergo!"
 
 egvTxCurrency :: EgvTx -> Currency
 egvTxCurrency e = case e of
@@ -119,12 +119,12 @@ setEgvTxMeta etx mh = case etx of
 
 
 instance ToJSON EgvTx where
-  toJSON egvTx@(BtcTx tx meta) = object [
+  toJSON (BtcTx tx meta) = object [
       "currency"  .= toJSON BTC
     , "tx"        .= btcTxToString tx
     , "meta"      .= toJSON meta
     ]
-  toJSON egvTx@(ErgTx tx meta) = object [
+  toJSON (ErgTx tx meta) = object [
       "currency"  .= toJSON ERGO
     , "tx"        .= ergTxToString tx
     , "meta"      .= toJSON meta

--- a/wallet-types/src/Ergvein/Types/Transaction.hs
+++ b/wallet-types/src/Ergvein/Types/Transaction.hs
@@ -183,15 +183,6 @@ instance ToJSON TxHash where
   toJSON = A.String . bs2Hex . BSS.fromShort . getTxHash
   {-# INLINE toJSON #-}
 
-instance FromJSON ShortByteString where
-  parseJSON = withText "ShortByteString" $
-    either (fail "Failed to parse a ShortByteString") (pure . BSS.toShort) . hex2bsTE
-  {-# INLINE parseJSON #-}
-
-instance ToJSON ShortByteString where
-  toJSON = A.String . bs2Hex . BSS.fromShort
-  {-# INLINE toJSON #-}
-
 instance FromJSONKey TxHash where
 instance ToJSONKey TxHash where
 

--- a/wallet-types/src/Ergvein/Types/Transaction.hs
+++ b/wallet-types/src/Ergvein/Types/Transaction.hs
@@ -97,12 +97,12 @@ egvTxCurrency e = case e of
   ErgTx{} -> ERGO
 
 egvTxFromJSON :: Currency -> Value -> Parser EgvTx
-egvTxFromJSON cur
-  | cur == BTC = withText "Bitcoin transaction" $ \t ->
+egvTxFromJSON = \case
+  BTC -> withText "Bitcoin transaction" $ \t ->
     case btcTxFromString t of
       Nothing -> fail "could not decode Bitcoin transaction"
       Just x  -> return $ BtcTx x Nothing
-  | cur == ERGO = withText "Ergo transaction" $ \t ->
+  ERGO -> withText "Ergo transaction" $ \t ->
     case ergTxFromString t of
       Nothing -> fail "could not decode Ergo transaction"
       Just x  -> return $ ErgTx x Nothing

--- a/wallet-types/src/Ergvein/Types/Transaction.hs
+++ b/wallet-types/src/Ergvein/Types/Transaction.hs
@@ -1,5 +1,5 @@
 module Ergvein.Types.Transaction (
-      BtcTx(..)
+      BtcTx
     , btcTxToString
     , btcTxFromString
     , ErgTx(..)
@@ -26,14 +26,13 @@ module Ergvein.Types.Transaction (
     , setEgvTxMeta
   ) where
 
-import Control.Monad (mzero, (<=<))
+import Control.Monad ((<=<))
 import Data.Aeson as A
 import Data.Aeson.Types (Parser)
 import Data.ByteString (ByteString)
 import Data.ByteString.Short (ShortByteString)
 import Control.DeepSeq
 import Data.Either
-import Data.String (IsString, fromString)
 import Data.Text as T
 import Data.Time
 import Data.Flat

--- a/wallet-types/src/Ergvein/Types/Utxo.hs
+++ b/wallet-types/src/Ergvein/Types/Utxo.hs
@@ -17,12 +17,10 @@ import Network.Haskoin.Script
 import Network.Haskoin.Transaction
 
 import Ergvein.Aeson
-import Ergvein.Types.Currency
 import Ergvein.Types.Keys
 import Ergvein.Types.Transaction
 
 import qualified Data.Map.Strict as M
-import qualified Data.Set as S
 
 data EgvUtxoStatus
   = EUtxoConfirmed

--- a/wallet-types/src/Ergvein/Types/Utxo.hs
+++ b/wallet-types/src/Ergvein/Types/Utxo.hs
@@ -77,6 +77,3 @@ reconfirmBtxUtxoSetPure bh bs = flip M.mapMaybe bs $ \meta -> case utxoMeta'stat
   EUtxoReceiving mh -> case mh of
     Nothing -> Just $ meta {utxoMeta'status = EUtxoReceiving $ Just bh}
     Just bh0 -> if bh - bh0 >= staleGap - 1 then Nothing else Just meta
-  where
-    keys = M.keys bs
-    foo b ta f = foldl' f b ta

--- a/wallet-types/src/Ergvein/Types/Utxo.hs
+++ b/wallet-types/src/Ergvein/Types/Utxo.hs
@@ -53,9 +53,6 @@ type BtcUtxoSet = M.Map OutPoint UtxoMeta
 -- snd's bool: True - confirmed, must be deleted from UTXO set, False - set status to EUtxoSending
 type BtcUtxoUpdate = (BtcUtxoSet, [(OutPoint, Bool)])
 
-instance FromJSONKey OutPoint
-instance ToJSONKey OutPoint
-
 updateBtcUtxoSetPure :: BtcUtxoUpdate -> BtcUtxoSet -> BtcUtxoSet
 updateBtcUtxoSetPure (outs, ins) s = foo (M.union outs s) ins $ \m (op, b) ->
   M.update (\meta -> if b then Nothing else Just meta {utxoMeta'status = EUtxoSending Nothing}) op m


### PR DESCRIPTION
Turns out that ergvien-wallet-types don't have -Wall in cabal which breaks strategy of adding support for cypra. So this PR:

 - Adds -Wall to cabal file
 - Fixes most of warnings
 - Puts all orphans in Orphanage module.