### PR TITLE
-Wall in dependencies of indexer server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ ergvein.hp
 ergvein.aux
 ergvein.ps
 *.prof
+TAGS

--- a/common/ergvein-common.cabal
+++ b/common/ergvein-common.cabal
@@ -7,6 +7,7 @@ build-type:          Simple
 cabal-version:       >=1.10
 
 library
+  Ghc-options:         -Wall
   hs-source-dirs:      src
   exposed-modules:
     Ergvein.Aeson

--- a/crypto/ergvein-crypto.cabal
+++ b/crypto/ergvein-crypto.cabal
@@ -20,6 +20,7 @@ maintainer:
                      - Vladimir Krutkin <krutkinvs@gmail.com>
 
 library
+  Ghc-options:         -Wall
   hs-source-dirs:      src
   exposed-modules:
     Ergvein.Crypto

--- a/crypto/src/Ergvein/Crypto/AES256.hs
+++ b/crypto/src/Ergvein/Crypto/AES256.hs
@@ -26,12 +26,9 @@ import Data.ByteArray (ByteArray, ByteArrayAccess, convert)
 import Data.ByteArray.Sized (SizedByteArray, unsafeSizedByteArray)
 import Data.ByteString (ByteString)
 import Data.Maybe
-import Data.Text
 import Data.Serialize
 import Ergvein.Crypto.PBKDF
-import Data.Text.Encoding (encodeUtf8)
 
-type Password = Text
 
 data Key c a where
   Key :: (BlockCipher c, ByteArray a) => a -> Key c a

--- a/crypto/src/Ergvein/Crypto/Keys.hs
+++ b/crypto/src/Ergvein/Crypto/Keys.hs
@@ -24,11 +24,11 @@ module Ergvein.Crypto.Keys (
 import Control.Monad            (unless, when)
 import Crypto.Hash              (SHA256 (..), hashWith)
 import Crypto.Secp256k1         (SecKey)
-import Data.Bits                (shiftL, shiftR)
+import Data.Bits                (shiftR)
 import Data.ByteString          (ByteString)
 import Data.Serialize.Get       (Get, getWord8)
 import Data.Serialize.Put       (Putter, putWord8, runPut)
-import Data.Vector              (Vector, (!))
+import Data.Vector              ((!))
 import Ergvein.Crypto.WordLists
 import Network.Haskoin.Util
 import Network.Haskoin.Address

--- a/index-api/ergvein-index-api.cabal
+++ b/index-api/ergvein-index-api.cabal
@@ -7,6 +7,7 @@ build-type:          Simple
 cabal-version:       >=1.10
 
 library
+  Ghc-options:         -Wall
   hs-source-dirs:      src
   exposed-modules:
       Ergvein.Index.API

--- a/index-api/src/Ergvein/Index/API/Types.hs
+++ b/index-api/src/Ergvein/Index/API/Types.hs
@@ -1,11 +1,9 @@
 module Ergvein.Index.API.Types where
 
 import Data.Map.Strict (Map)
-import Data.Maybe
 import Data.Text
 import Data.Word
 import GHC.Generics
-import Servant.Client.Core
 
 import Ergvein.Aeson
 import Ergvein.Types.Currency

--- a/index-client/ergvein-index-client.cabal
+++ b/index-client/ergvein-index-client.cabal
@@ -12,6 +12,7 @@ author:              Levon Oganyan
 maintainer:          Levon Oganyan <lemarwin@protonmail.com>
 
 library
+  ghc-options:         -Wall
   hs-source-dirs:      src
   exposed-modules:
     Ergvein.Index.Client

--- a/index-client/src/Ergvein/Index/Client/V1.hs
+++ b/index-client/src/Ergvein/Index/Client/V1.hs
@@ -14,7 +14,6 @@ import Control.Monad.IO.Class
 import Control.Monad.Reader
 import Data.Proxy
 import Network.HTTP.Client hiding (Proxy)
-import Servant.API
 import Servant.API.Generic
 import Servant.Client
 
@@ -23,7 +22,7 @@ import Ergvein.Index.API.Types
 import Ergvein.Index.API.V1
 import Ergvein.Text
 import Ergvein.Types.Currency
-import Ergvein.Types.Orphanage
+import Ergvein.Types.Orphanage ()
 import Ergvein.Wallet.Native
 
 data AsClient

--- a/index-protocol-client/ergvein-index-protocol-client.cabal
+++ b/index-protocol-client/ergvein-index-protocol-client.cabal
@@ -7,6 +7,7 @@ build-type:          Simple
 cabal-version:       >=1.10
 
 library
+  ghc-options:         -Wall
   hs-source-dirs:      src
   exposed-modules:
     Ergvein.Index.Protocol.Client.V1

--- a/index-protocol/ergvein-index-protocol.cabal
+++ b/index-protocol/ergvein-index-protocol.cabal
@@ -7,6 +7,7 @@ build-type:          Simple
 cabal-version:       >=1.10
 
 library
+  ghc-options:         -Wall
   hs-source-dirs:      src
   exposed-modules:
     Ergvein.Index.Protocol.Types

--- a/index-protocol/src/Ergvein/Index/Protocol/Deserialization.hs
+++ b/index-protocol/src/Ergvein/Index/Protocol/Deserialization.hs
@@ -35,7 +35,11 @@ word32toMessageType = \case
   _  -> Nothing
 
 currencyCodeParser :: Parser CurrencyCode
-currencyCodeParser = fmap word32ToCurrencyCode anyWord32le
+currencyCodeParser = do
+  w <- anyWord32le
+  case word32ToCurrencyCode w of
+    Nothing -> fail "Invalid currency code"
+    Just c  -> pure c
 
 word32toRejectType :: Word32 -> Maybe RejectCode
 word32toRejectType = \case

--- a/index-protocol/src/Ergvein/Index/Protocol/Deserialization.hs
+++ b/index-protocol/src/Ergvein/Index/Protocol/Deserialization.hs
@@ -99,7 +99,9 @@ filterParser = do
 
 addressParser :: Parser Address
 addressParser = do
-  addrType <- word8ToIPType <$> anyWord8
+  addrType <-  maybe (fail "Invalid address type") pure
+            .  word8ToIPType
+           =<< anyWord8
   addrPort <- anyWord16le
   addr <- Parse.take (if addrType == IPV4 then 4 else 16)
   pure $ Address

--- a/index-protocol/src/Ergvein/Index/Protocol/Deserialization.hs
+++ b/index-protocol/src/Ergvein/Index/Protocol/Deserialization.hs
@@ -4,7 +4,6 @@ import Codec.Compression.GZip
 import Control.Monad
 import Data.Attoparsec.Binary
 import Data.Attoparsec.ByteString
-import Data.List
 import Data.Word
 
 import Ergvein.Index.Protocol.Types

--- a/index-protocol/src/Ergvein/Index/Protocol/Serialization.hs
+++ b/index-protocol/src/Ergvein/Index/Protocol/Serialization.hs
@@ -101,7 +101,7 @@ messageBuilder (MReject msg) = messageBase MRejectType msgSize $ word32LE reject
     rejectType = rejectTypeToWord32 $ rejectMsgCode msg
     msgSize = genericSizeOf rejectType
 
-messageBuilder (MVersionACK msg) = messageBase MVersionACKType msgSize $ word8 msg
+messageBuilder (MVersionACK VersionACK) = messageBase MVersionACKType msgSize $ word8 msg
   where
     msg = 0 :: Word8
     msgSize = genericSizeOf msg
@@ -142,7 +142,7 @@ messageBuilder (MFiltersResponse FilterResponse {..}) =
   <> word32LE filtersCount
   <> lazyByteString zippedFilters
   where
-    (filtersSizeSum, filters) = mconcat $ blockFilterBuilder <$> V.toList filterResponseFilters
+    (_filtersSizeSum, filters) = mconcat $ blockFilterBuilder <$> V.toList filterResponseFilters
     filtersCount = fromIntegral $ V.length filterResponseFilters
     zippedFilters = compress $ toLazyByteString filters
 

--- a/index-protocol/src/Ergvein/Index/Protocol/Types.hs
+++ b/index-protocol/src/Ergvein/Index/Protocol/Types.hs
@@ -6,11 +6,9 @@ import Data.Vector.Unboxed.Deriving
 import Data.Word
 import Foreign.C.Types
 import Foreign.Storable
-import Language.Haskell.TH
 
 import Ergvein.Types.Fees
 
-import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as UV
 
@@ -44,6 +42,7 @@ data CurrencyCode = BTC   | TBTC
                   | DASH  | TDASH
   deriving (Eq, Ord, Enum, Bounded, Show)
 
+currencyCodeToWord32 :: CurrencyCode -> Word32
 currencyCodeToWord32 = \case
   BTC    -> 0
   TBTC   -> 1
@@ -60,6 +59,7 @@ currencyCodeToWord32 = \case
   DASH   -> 12
   TDASH  -> 13
 
+word32ToCurrencyCode :: Word32 -> CurrencyCode
 word32ToCurrencyCode = \case
   0  -> BTC
   1  -> TBTC

--- a/index-protocol/src/Ergvein/Index/Protocol/Types.hs
+++ b/index-protocol/src/Ergvein/Index/Protocol/Types.hs
@@ -59,27 +59,28 @@ currencyCodeToWord32 = \case
   DASH   -> 12
   TDASH  -> 13
 
-word32ToCurrencyCode :: Word32 -> CurrencyCode
+word32ToCurrencyCode :: Word32 -> Maybe CurrencyCode
 word32ToCurrencyCode = \case
-  0  -> BTC
-  1  -> TBTC
-  2  -> ERGO
-  3  -> TERGO
-  4  -> USDTO
-  5  -> TUSDTO
-  6  -> LTC
-  7  -> TLTC
-  8  -> ZEC
-  9  -> TZEC
-  10 -> CPR
-  11 -> TCPR
-  12 -> DASH
-  13 -> TDASH
+  0  -> Just BTC
+  1  -> Just TBTC
+  2  -> Just ERGO
+  3  -> Just TERGO
+  4  -> Just USDTO
+  5  -> Just TUSDTO
+  6  -> Just LTC
+  7  -> Just TLTC
+  8  -> Just ZEC
+  9  -> Just TZEC
+  10 -> Just CPR
+  11 -> Just TCPR
+  12 -> Just DASH
+  13 -> Just TDASH
+  _  -> Nothing
 
 derivingUnbox "CurrencyCode"
-  [t| CurrencyCode -> Word32 |]
-  [| currencyCodeToWord32    |]
-  [| word32ToCurrencyCode    |]
+  [t| CurrencyCode -> Word8  |]
+  [| fromIntegral . fromEnum |]
+  [| toEnum . fromIntegral   |]
 
 data MessageHeader = MessageHeader
   { msgType :: !MessageType

--- a/index-protocol/src/Ergvein/Index/Protocol/Types.hs
+++ b/index-protocol/src/Ergvein/Index/Protocol/Types.hs
@@ -162,10 +162,11 @@ ipTypeToWord8 = \case
   IPV4 -> 0
   IPV6 -> 1
 
-word8ToIPType :: Word8 -> IPType
+word8ToIPType :: Word8 -> Maybe IPType
 word8ToIPType = \case
-  0 -> IPV4
-  1 -> IPV6
+  0 -> Just IPV4
+  1 -> Just IPV6
+  _ -> Nothing
 
 data Address = Address
   { addressType    :: !IPType

--- a/index-server/ergvein-index-server.cabal
+++ b/index-server/ergvein-index-server.cabal
@@ -12,6 +12,7 @@ author:              Anton Gushcha, Aminion, Vladimir Krutkin, Levon Oganyan
 maintainer:          Anton Gushcha <ncrashed@protonmail.com>, Vladimir Krutkin <krutkinvs@gmail.com>
 
 library
+  ghc-options:         -Wall
   hs-source-dirs:      src
   exposed-modules:
     Ergvein.Index.Server.App

--- a/index-server/src/Ergvein/Index/Server/App.hs
+++ b/index-server/src/Ergvein/Index/Server/App.hs
@@ -34,8 +34,8 @@ onStartup onlyScan _ = do
 
 onShutdown :: ServerEnv -> IO ()
 onShutdown env = do
-  T.putStrLn $ showt "Server stop signal recivied..."
-  T.putStrLn $ showt "service is stopping"
+  T.putStrLn "Server stop signal recivied..."
+  T.putStrLn "service is stopping"
   atomically $ writeTVar (envShutdownFlag env) True
 
 finalize :: (MonadIO m, MonadLogger m) => ServerEnv -> [Thread] -> [Thread] -> m ()

--- a/index-server/src/Ergvein/Index/Server/App.hs
+++ b/index-server/src/Ergvein/Index/Server/App.hs
@@ -15,7 +15,6 @@ import Ergvein.Index.Server.DB.Schema.Indexer (RollbackSequence(..))
 import Ergvein.Index.Server.Environment
 import Ergvein.Index.Server.Metrics
 import Ergvein.Index.Server.Monad
-import Ergvein.Index.Server.PeerDiscovery.Discovery
 import Ergvein.Index.Server.TCPService.Server
 import Ergvein.Index.Server.Utils
 import Ergvein.Text

--- a/index-server/src/Ergvein/Index/Server/BlockchainScanning/Common.hs
+++ b/index-server/src/Ergvein/Index/Server/BlockchainScanning/Common.hs
@@ -5,7 +5,6 @@ import Control.Immortal
 import Control.Monad.Catch
 import Control.Monad.Logger
 import Control.Monad.Reader
-import Conversion
 import Data.Maybe
 import Data.Time
 import System.DiskSpace

--- a/index-server/src/Ergvein/Index/Server/BlockchainScanning/Ergo.hs
+++ b/index-server/src/Ergvein/Index/Server/BlockchainScanning/Ergo.hs
@@ -1,16 +1,12 @@
 module Ergvein.Index.Server.BlockchainScanning.Ergo where
 
 import  Control.Monad.Reader
-import  Data.List.Index
 import  Data.Maybe
-import  Data.Serialize
 
-import Ergvein.Crypto.Hash
 import Ergvein.Index.Server.BlockchainScanning.Types
 import Ergvein.Interfaces.Ergo.Api
 import Ergvein.Interfaces.Ergo.It.Api.NodeApi
 import Ergvein.Interfaces.Ergo.Scorex.Core.Block
-import Ergvein.Text
 import Ergvein.Types.Currency
 import Ergvein.Types.Transaction
 
@@ -21,7 +17,6 @@ import qualified Network.Ergo.Api.Utxo    as UtxoApi
 import qualified Data.ByteString.Short as BSS
 import qualified Data.Map.Strict as M
 
-import Control.Monad.IO.Unlift
 
 txInfo :: ApiMonad m => ErgoTransaction -> m ([TxInfo], [TxHash])
 txInfo tx = do

--- a/index-server/src/Ergvein/Index/Server/DB.hs
+++ b/index-server/src/Ergvein/Index/Server/DB.hs
@@ -14,7 +14,6 @@ import Database.LevelDB.Base
 import Database.LevelDB.Internal
 import System.Directory
 import System.FilePath
-import Ergvein.Text
 
 import Ergvein.Index.Server.DB.Monad
 import Ergvein.Index.Server.DB.Queries (initIndexerDb)

--- a/index-server/src/Ergvein/Index/Server/DB/Conversions.hs
+++ b/index-server/src/Ergvein/Index/Server/DB/Conversions.hs
@@ -2,12 +2,9 @@ module Ergvein.Index.Server.DB.Conversions where
 
 import Conversion
 import Data.ByteString.Builder
-import Data.Maybe
 import Data.Text
 import Data.Either
 import Ergvein.Index.Protocol.Types
-import Ergvein.Index.Server.BlockchainScanning.Types
-import Ergvein.Index.Server.DB.Schema.Filters
 import Ergvein.Index.Server.PeerDiscovery.Types as DiscoveryTypes
 import Network.Socket
 import Ergvein.Index.Server.DB.Schema.Indexer

--- a/index-server/src/Ergvein/Index/Server/DB/Queries.hs
+++ b/index-server/src/Ergvein/Index/Server/DB/Queries.hs
@@ -24,7 +24,6 @@ module Ergvein.Index.Server.DB.Queries
 
 import Control.Concurrent.Async.Lifted
 import Control.Concurrent.STM
-import Control.Monad
 import Control.Monad.IO.Class
 import Control.Monad.Logger
 import Control.Monad.Trans.Control

--- a/index-server/src/Ergvein/Index/Server/DB/Serialize.hs
+++ b/index-server/src/Ergvein/Index/Server/DB/Serialize.hs
@@ -4,7 +4,6 @@ module Ergvein.Index.Server.DB.Serialize
   , putTxInfosAsRecs
   , serializeWord32
   , deserializeWord32
-  , module Ergvein.Index.Server.DB.Serialize.Tx
   ) where
 
 import Control.DeepSeq
@@ -17,7 +16,7 @@ import Data.ByteString.Builder as BB
 import Data.Foldable
 import Data.Word
 
-import Ergvein.Index.Server.DB.Serialize.Tx
+import Ergvein.Index.Server.DB.Serialize.Tx ()
 import Ergvein.Index.Server.BlockchainScanning.Types
 import Ergvein.Index.Server.PeerDiscovery.Types
 import Ergvein.Index.Server.DB.Schema.Filters

--- a/index-server/src/Ergvein/Index/Server/DB/Serialize.hs
+++ b/index-server/src/Ergvein/Index/Server/DB/Serialize.hs
@@ -59,7 +59,7 @@ instance EgvSerialize TxRecBytes where
 -- ===========================================================================
 
 instance EgvSerialize BlockMetaRec where
-  egvSerialize cur (BlockMetaRec hd filt) = BL.toStrict . toLazyByteString $ let
+  egvSerialize _ (BlockMetaRec hd filt) = BL.toStrict . toLazyByteString $ let
     len = fromIntegral $ BS.length filt
     in shortByteString hd <> word64LE len <> byteString filt
   egvDeserialize cur = parseOnly $ do

--- a/index-server/src/Ergvein/Index/Server/DB/Serialize/Tx.hs
+++ b/index-server/src/Ergvein/Index/Server/DB/Serialize/Tx.hs
@@ -8,14 +8,12 @@ import Data.Attoparsec.Binary
 import Data.Attoparsec.ByteString hiding (word8)
 import Data.ByteString.Builder
 import Data.Either
-import Data.Word
 import Network.Haskoin.Crypto
 import Network.Haskoin.Transaction hiding (buildTx)
 
 import Ergvein.Index.Server.DB.Serialize.Class
 
 import qualified Data.Attoparsec.ByteString as A
-import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.Serialize as S
 

--- a/index-server/src/Ergvein/Index/Server/DB/Utils.hs
+++ b/index-server/src/Ergvein/Index/Server/DB/Utils.hs
@@ -26,8 +26,6 @@ import Data.Text.Encoding
 import Data.Time
 import Database.LevelDB
 import Database.LevelDB.Iterator
-import Ergvein.Index.Server.Dependencies
-import System.ByteOrder
 
 import Ergvein.Index.Server.DB.Serialize.Class
 import Ergvein.Types.Currency

--- a/index-server/src/Ergvein/Index/Server/Dependencies.hs
+++ b/index-server/src/Ergvein/Index/Server/Dependencies.hs
@@ -16,17 +16,14 @@ module Ergvein.Index.Server.Dependencies
 
 import Control.Concurrent
 import Control.Concurrent.STM
-import Control.Concurrent.STM.TVar
 import Control.Monad.IO.Unlift
-import Data.Map.Strict (Map(..))
+import Data.Map.Strict (Map)
 import Ergvein.Index.Protocol.Types (CurrencyCode, Message)
 import Ergvein.Index.Server.PeerDiscovery.Types
 import Ergvein.Types.Fees
-import Network.HTTP.Client
 import Network.Socket
 
 import qualified Data.Map.Strict            as Map
-import qualified Network.HTTP.Client        as HC
 import qualified Network.Haskoin.Constants  as HK
 
 class HasBitcoinNodeNetwork m where

--- a/index-server/src/Ergvein/Index/Server/Monad.hs
+++ b/index-server/src/Ergvein/Index/Server/Monad.hs
@@ -1,6 +1,5 @@
 module Ergvein.Index.Server.Monad where
 
-import Control.Concurrent
 import Control.Concurrent.STM
 import Control.Immortal
 import Control.Monad.Base
@@ -9,7 +8,6 @@ import Control.Monad.IO.Unlift
 import Control.Monad.Logger
 import Control.Monad.Reader
 import Control.Monad.Trans.Control
-import Network.Socket
 import Prometheus (MonadMonitor(..))
 
 import Ergvein.Index.Client
@@ -19,10 +17,8 @@ import Ergvein.Index.Server.Config
 import Ergvein.Index.Server.DB.Monad
 import Ergvein.Index.Server.Dependencies
 import Ergvein.Index.Server.Environment
-import Ergvein.Types.Fees
 
 import qualified Data.Map.Strict as M
-import qualified Network.Bitcoin.Api.Client  as BitcoinApi
 import qualified Network.Ergo.Api.Client     as ErgoApi
 
 newtype ServerM a = ServerM { unServerM :: ReaderT ServerEnv (LoggingT IO) a }

--- a/index-server/src/Ergvein/Index/Server/PeerDiscovery/Discovery.hs
+++ b/index-server/src/Ergvein/Index/Server/PeerDiscovery/Discovery.hs
@@ -9,7 +9,6 @@ module Ergvein.Index.Server.PeerDiscovery.Discovery
 import Control.Concurrent.STM
 import Control.Immortal
 import Control.Monad.Random
-import Conversion
 import Data.Foldable
 import Data.Set (Set)
 import Data.Time.Clock

--- a/index-server/src/Ergvein/Index/Server/PeerDiscovery/Types.hs
+++ b/index-server/src/Ergvein/Index/Server/PeerDiscovery/Types.hs
@@ -8,13 +8,9 @@ module Ergvein.Index.Server.PeerDiscovery.Types
   )where
 
 import Data.Set (Set)
-import Data.Text
 import Data.Time
-import Data.Time.Clock
 import Data.Word
 import Ergvein.Index.Protocol.Types
-import Ergvein.Types.Currency
-import Ergvein.Types.Transaction
 import Network.Socket
 import GHC.Generics
 

--- a/index-server/src/Ergvein/Index/Server/TCPService/Connections.hs
+++ b/index-server/src/Ergvein/Index/Server/TCPService/Connections.hs
@@ -7,11 +7,8 @@ module Ergvein.Index.Server.TCPService.Connections
 
 import Control.Concurrent
 import Control.Concurrent.STM
-import Control.Concurrent.STM.TVar
 import Control.Monad.IO.Unlift
-import Data.Map.Strict (Map(..))
 import Data.Maybe
-import Ergvein.Index.Protocol.Types (CurrencyCode, Message)
 import Ergvein.Index.Server.Dependencies
 import Network.Socket
 

--- a/index-server/src/Ergvein/Index/Server/TCPService/Connections.hs
+++ b/index-server/src/Ergvein/Index/Server/TCPService/Connections.hs
@@ -9,6 +9,7 @@ import Control.Concurrent
 import Control.Concurrent.STM
 import Control.Monad.IO.Unlift
 import Data.Maybe
+import Data.Foldable
 import Ergvein.Index.Server.Dependencies
 import Network.Socket
 
@@ -36,5 +37,5 @@ closeAllConnections :: HasConnectionsManagement m => m ()
 closeAllConnections = do
   openedConnectionsRef <- openConnections
   liftIO $ do
-    traverse closeSocketAndKillThread =<< Map.elems <$> readTVarIO openedConnectionsRef
+    traverse_ closeSocketAndKillThread =<< Map.elems <$> readTVarIO openedConnectionsRef
     atomically $ writeTVar openedConnectionsRef mempty

--- a/index-server/src/Ergvein/Index/Server/TCPService/Conversions.hs
+++ b/index-server/src/Ergvein/Index/Server/TCPService/Conversions.hs
@@ -5,7 +5,6 @@ import Conversion
 import Ergvein.Index.Protocol.Types
 import Ergvein.Index.Server.DB.Schema.Filters
 import Ergvein.Index.Server.BlockchainScanning.Types
-import Ergvein.Text
 import Ergvein.Index.Server.Config
 
 import qualified Ergvein.Types.Currency as C

--- a/index-server/src/Ergvein/Index/Server/TCPService/MessageHandler.hs
+++ b/index-server/src/Ergvein/Index/Server/TCPService/MessageHandler.hs
@@ -4,9 +4,6 @@ import Control.Concurrent.STM
 import Control.Monad.IO.Class
 import Control.Monad.Reader
 import Conversion
-import Data.Time.Clock.POSIX
-import Control.Monad.Random
-import Conversion
 import Network.Socket
 
 import Ergvein.Index.Protocol.Types as IPT

--- a/index-server/src/Ergvein/Index/Server/TCPService/MessageHandler.hs
+++ b/index-server/src/Ergvein/Index/Server/TCPService/MessageHandler.hs
@@ -40,11 +40,11 @@ getBlockMetaSlice currency startHeight amount = do
   pure $ snd <$> slice
 
 handleMsg :: SockAddr -> Message -> ServerM [Message]
-handleMsg address (MPing msg) = pure [MPong msg]
+handleMsg _ (MPing msg) = pure [MPong msg]
 
-handleMsg address (MPong _) = pure mempty
+handleMsg _ (MPong _) = pure mempty
 
-handleMsg address (MVersionACK _) = pure mempty
+handleMsg _ (MVersionACK _) = pure mempty
 
 handleMsg address (MVersion peerVersion) = do
   ownVer <- ownVersion
@@ -54,11 +54,11 @@ handleMsg address (MVersion peerVersion) = do
   else
     pure mempty
 
-handleMsg address (MPeerRequest _) = do
+handleMsg _ (MPeerRequest _) = do
   knownPeers <- getActualPeers
   pure $ pure $ MPeerResponse $ PeerResponse $ V.fromList knownPeers
 
-handleMsg address (MFiltersRequest FilterRequest {..}) = do
+handleMsg _ (MFiltersRequest FilterRequest {..}) = do
   currency <- currencyCodeToCurrency filterRequestMsgCurrency
   slice <- getBlockMetaSlice currency filterRequestMsgStart filterRequestMsgAmount
   let filters = V.fromList $ convert <$> slice
@@ -79,7 +79,7 @@ handleMsg address (MFiltersEvent FilterEvent {..}) = do
   pure mempty
 
 
-handleMsg address (MFeeRequest curs) = do
+handleMsg _ (MFeeRequest curs) = do
   fees <- liftIO . readTVarIO =<< asks envFeeEstimates
   let selCurs = M.restrictKeys fees $ S.fromList curs
   let resps =  (`M.mapWithKey` selCurs) $ \cur fb -> case cur of

--- a/index-server/src/Ergvein/Index/Server/TCPService/Server.hs
+++ b/index-server/src/Ergvein/Index/Server/TCPService/Server.hs
@@ -145,7 +145,7 @@ runConnection (sock, addr) = incGaugeWhile activeConnsGauge $ do
 
         messageHeaderBytes :: ExceptT Reject ServerM BS.ByteString
         messageHeaderBytes = do
-          fetchedBytes <- lift $ liftIO messageHeaderBytesFetch
+          fetchedBytes <- liftIO messageHeaderBytesFetch
           if not (BS.null fetchedBytes) then
             except $ Right fetchedBytes
           else

--- a/index-server/src/Ergvein/Index/Server/TCPService/Server.hs
+++ b/index-server/src/Ergvein/Index/Server/TCPService/Server.hs
@@ -54,7 +54,7 @@ tcpSrv thread = do
     addr <- resolve port host
     sock <- socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr)
     bind sock (addrAddress addr)
-    listen sock 5
+    listen sock numberOfQueuedConnections
     unliftIO unlift $ mainLoop thread sock
   where
     numberOfQueuedConnections = 5
@@ -160,4 +160,4 @@ runConnection (sock, addr) = incGaugeWhile activeConnsGauge $ do
           except $ mapLeft (\_-> Reject MessageParsing) $ eitherResult $ parse (messageParser msgType) messageBytes
 
         response :: Message -> ExceptT Reject ServerM [Message]
-        response msg = (lift $ handleMsg addr msg) `catch` (\(SomeException ex) -> except $ Left $ Reject InternalServerError)
+        response msg = (lift $ handleMsg addr msg) `catch` (\SomeException{} -> except $ Left $ Reject InternalServerError)

--- a/index-server/src/Ergvein/Index/Server/TCPService/Server.hs
+++ b/index-server/src/Ergvein/Index/Server/TCPService/Server.hs
@@ -9,17 +9,11 @@ import Control.Monad.Catch
 import Control.Monad.IO.Unlift
 import Control.Monad.Logger
 import Control.Monad.Random
-import Control.Monad.Reader
 import Control.Monad.Trans.Except
 import Data.Attoparsec.ByteString
 import Data.ByteString.Builder
 import Data.Either.Combinators
-import Data.Foldable (traverse_)
-import Data.Time.Clock.POSIX
-import Data.Word
 import Network.Socket
-import Network.Socket.ByteString.Lazy
-import System.IO
 
 import Ergvein.Text
 import Ergvein.Index.Protocol.Deserialization

--- a/index-server/src/Ergvein/Index/Server/TCPService/Server.hs
+++ b/index-server/src/Ergvein/Index/Server/TCPService/Server.hs
@@ -97,7 +97,7 @@ runConnection (sock, addr) = incGaugeWhile activeConnsGauge $ do
   case evalResult of
     Right (msgs@(MVersionACK _ : _)) -> do --peer version match ours
       sendChan <- liftIO newTChanIO
-      forM msgs $ (liftIO . writeMsg sendChan)
+      liftIO $ forM_ msgs $ writeMsg sendChan
       -- Spawn message sender thread
       fork $ sendLoop sendChan
       -- Spawn broadcaster loop
@@ -129,7 +129,7 @@ runConnection (sock, addr) = incGaugeWhile activeConnsGauge $ do
           evalResult <- runExceptT $ evalMsg
           case evalResult of
             Right msgs -> do
-              forM msgs $ (liftIO . writeMsg destinationChan)
+              liftIO $ forM_ msgs $ writeMsg destinationChan
               listenLoop'
             Left Reject {..} | rejectMsgCode == ZeroBytesReceived -> do
               logInfoN $ "<" <> showt addr <> ">: Client closed the connection"

--- a/index-server/src/Ergvein/Index/Server/Utils.hs
+++ b/index-server/src/Ergvein/Index/Server/Utils.hs
@@ -1,9 +1,7 @@
 module Ergvein.Index.Server.Utils where
 
 import Control.Concurrent.STM
-import Control.Concurrent.STM.TVar
 import Control.Monad
-import Data.Foldable
 import Data.Hashable
 import Data.Word
 import System.Timeout

--- a/wallet-filters/ergvein-wallet-filters.cabal
+++ b/wallet-filters/ergvein-wallet-filters.cabal
@@ -12,6 +12,7 @@ author:              Anton Gushcha, Aminion, Vladimir Krutkin, Levon Oganyan, Se
 maintainer:          Anton Gushcha <ncrashed@protonmail.com>
 
 library
+  ghc-options:         -Wall
   hs-source-dirs:      src
   exposed-modules:
     Ergvein.Filters

--- a/wallet-filters/src/Ergvein/Filters/Btc.hs
+++ b/wallet-filters/src/Ergvein/Filters/Btc.hs
@@ -16,9 +16,7 @@ module Ergvein.Filters.Btc
 where
 
 import           Crypto.Hash                    ( SHA256 (..), hashWith)
-import           Data.ByteArray.Hash            ( SipKey(..) )
 import           Data.ByteString                ( ByteString )
-import           Data.Serialize                 ( encode )
 import           Data.Word
 import           Ergvein.Filters.Btc.Index
 import           Ergvein.Filters.Btc.VarInt
@@ -33,7 +31,6 @@ import qualified Data.ByteString               as BS
 import qualified Data.ByteString.Builder       as B
 import qualified Data.ByteString.Lazy          as BSL
 import qualified Data.HashSet                  as HS
-import qualified Data.Vector                   as V
 
 -- | BIP 158 filter that tracks only Bech32 SegWit addresses that are used in specific block.
 data BtcAddrFilter = BtcAddrFilter {

--- a/wallet-filters/src/Ergvein/Filters/Btc/Mutable.hs
+++ b/wallet-filters/src/Ergvein/Filters/Btc/Mutable.hs
@@ -19,9 +19,7 @@ where
 import           Control.DeepSeq
 import           Control.Monad.IO.Class
 import           Crypto.Hash                    ( SHA256 (..), hashWith)
-import           Data.ByteArray.Hash            ( SipKey(..) )
 import           Data.ByteString                ( ByteString )
-import           Data.Serialize                 ( encode )
 import           Data.Word
 import           Ergvein.Filters.Btc.Index
 import           Ergvein.Filters.Btc.VarInt
@@ -36,7 +34,6 @@ import qualified Data.ByteString               as BS
 import qualified Data.ByteString.Builder       as B
 import qualified Data.ByteString.Lazy          as BSL
 import qualified Data.HashSet                  as HS
-import qualified Data.Vector                   as V
 
 -- | BIP 158 filter that tracks only Bech32 SegWit addresses that are used in specific block.
 data BtcAddrFilter = BtcAddrFilter {

--- a/wallet-filters/src/Ergvein/Filters/GCS.hs
+++ b/wallet-filters/src/Ergvein/Filters/GCS.hs
@@ -25,7 +25,6 @@ module Ergvein.Filters.GCS(
 import Control.Monad.ST (runST)
 import Data.ByteString (ByteString)
 import Data.HashSet (HashSet)
-import Data.Vector (Vector)
 import Data.Word
 import Ergvein.Filters.Hash
 

--- a/wallet-filters/src/Ergvein/Filters/GCS/Mutable.hs
+++ b/wallet-filters/src/Ergvein/Filters/GCS/Mutable.hs
@@ -27,7 +27,6 @@ import Control.Monad.IO.Class
 import Control.Monad.ST (runST)
 import Data.ByteString (ByteString)
 import Data.HashSet (HashSet)
-import Data.Vector (Vector)
 import Data.Word
 import Ergvein.Filters.Hash
 


### PR DESCRIPTION
Notable changes:

 - Parsers for currency codes and IP address type are won't throw exceptions anymore
 - Unbox instances for currency code uses Word8 underneath. No reason to waste whole 4 bytes per code