### PR TITLE
Publish reflex auxiliary libraries to hackage 

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,6 +14,7 @@ packages:
   ./interfaces/ergo
   ./reflex-external-ref
   ./reflex-localize
+  ./reflex-localize-dom
   ./retractable
   ./wallet
   ./wallet-android

--- a/default.nix
+++ b/default.nix
@@ -34,6 +34,7 @@ let
       reflex-dom-retractable = ./retractable;
       reflex-external-ref = ./reflex-external-ref;
       reflex-localize = ./reflex-localize;
+      reflex-localize-dom = ./reflex-localize-dom;
       ui-playground = ./ui-playground;
       x509-android = ./x509-android;
     };

--- a/overrides.nix
+++ b/overrides.nix
@@ -63,6 +63,7 @@ in (self: super: let
     reflex-dom-retractable = ingnoreGarbage super.reflex-dom-retractable;
     reflex-external-ref = ingnoreGarbage super.reflex-external-ref;
     reflex-localize = ingnoreGarbage super.reflex-localize;
+    reflex-localize-dom = ingnoreGarbage super.reflex-localize-dom;
     # Overridess
     android-activity = self.callPackage ./derivations/android-activity.nix {
       inherit (pkgs.buildPackages) jdk;

--- a/reflex-external-ref/CHANGELOG.md
+++ b/reflex-external-ref/CHANGELOG.md
@@ -1,3 +1,13 @@
+1.0.3.1
+=======
+
+Add description and README file.
+
+1.0.3.0
+=======
+
+Bump versions of reflex. Drop dependency on `reflex-dom`
+
 1.0.2.0
 =======
 

--- a/reflex-external-ref/README.md
+++ b/reflex-external-ref/README.md
@@ -1,0 +1,5 @@
+# reflex-external-ref
+
+The package provides you with `IORef` that has attached reflex `Event`. Each time
+the variable changes the event fires. It is very useful for communication with
+external event sources or using it as environment level state.

--- a/reflex-external-ref/reflex-external-ref.cabal
+++ b/reflex-external-ref/reflex-external-ref.cabal
@@ -1,7 +1,10 @@
 name:                reflex-external-ref
-version:             1.0.3.0
+version:             1.0.3.1
 synopsis:            External reference with reactivity support
-description:         See README.md
+description:
+  The package provides you with `IORef` that has attached reflex `Event`. Each time
+  the variable changes the event fires. It is very useful for communication with
+  external event sources or using it as environment level state.
 stability:           Experimental
 category:            Reflex, FRP, Web, GUI, HTML, Javascript, Reactive, Reactivity, User Interfaces, User-interface
 build-type:          Simple
@@ -20,13 +23,16 @@ maintainer:          - Anton Gushcha <ncrashed@gmail.com>
                      - Levon Oganyan
 bug-reports:         https://github.com/hexresearch/ergvein/issues
 homepage:            https://github.com/hexresearch/ergvein
+extra-source-files:
+  README.md
+  CHANGELOG.md
 
 library
   hs-source-dirs:      src
   exposed-modules:
     Reflex.ExternalRef
   build-depends:
-      base
+      base                      >= 4.5      && < 4.15
     , reflex                    >= 0.4      && < 0.9
     , deepseq                   >= 1.4      && < 1.5
   default-language:    Haskell2010
@@ -34,3 +40,4 @@ library
 source-repository head
   type:     git
   location: https://github.com/hexresearch/ergvein.git
+  subdir:   reflex-external-ref

--- a/reflex-external-ref/reflex-external-ref.cabal
+++ b/reflex-external-ref/reflex-external-ref.cabal
@@ -1,5 +1,5 @@
 name:                reflex-external-ref
-version:             1.0.2.0
+version:             1.0.3.0
 synopsis:            External reference with reactivity support
 description:         See README.md
 stability:           Experimental
@@ -18,6 +18,8 @@ maintainer:          - Anton Gushcha <ncrashed@gmail.com>
                      - Aminion <>
                      - Vladimir Krutkin <krutkinvs@gmail.com>
                      - Levon Oganyan
+bug-reports:         https://github.com/hexresearch/ergvein/issues
+homepage:            https://github.com/hexresearch/ergvein
 
 library
   hs-source-dirs:      src
@@ -25,7 +27,10 @@ library
     Reflex.ExternalRef
   build-depends:
       base
-    , reflex                    >= 0.4      && < 0.7
-    , reflex-dom                >= 0.4      && < 0.7
+    , reflex                    >= 0.4      && < 0.9
     , deepseq                   >= 1.4      && < 1.5
   default-language:    Haskell2010
+
+source-repository head
+  type:     git
+  location: https://github.com/hexresearch/ergvein.git

--- a/reflex-external-ref/src/Reflex/ExternalRef.hs
+++ b/reflex-external-ref/src/Reflex/ExternalRef.hs
@@ -30,7 +30,6 @@ import Control.Monad.IO.Class
 import Data.IORef
 import GHC.Generics
 import Reflex
-import Reflex.Dom
 
 -- | Holds value of type `a` and provides ways for notifying FRP network about
 -- changes of the variable.

--- a/reflex-external-ref/upload-docs.sh
+++ b/reflex-external-ref/upload-docs.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -xe
+
+rm ../dist-newstyle/reflex-external-ref-*-docs.tar.gz || true
+
+# assumes cabal 2.4 or later
+cabal v2-haddock --haddock-for-hackage --enable-doc
+
+cabal upload -d --publish ../dist-newstyle/reflex-external-ref-*.tar.gz

--- a/reflex-external-ref/upload.sh
+++ b/reflex-external-ref/upload.sh
@@ -1,0 +1,4 @@
+set -xe
+rm ../dist-newstyle/sdist -rf | true
+cabal new-sdist
+cabal upload --publish ../dist-newstyle/sdist/reflex-external-ref-*.tar.gz

--- a/reflex-localize-dom/CHANGELOG.md
+++ b/reflex-localize-dom/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 1.0.0.0
+
+* Initial release

--- a/reflex-localize-dom/LICENSE
+++ b/reflex-localize-dom/LICENSE
@@ -1,0 +1,7 @@
+Copyright 2019 ATUM SOLUTIONS AG
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/reflex-localize-dom/README.md
+++ b/reflex-localize-dom/README.md
@@ -1,0 +1,81 @@
+# reflex-localize-dom
+
+Dom extensions for [reflex-localize](../reflex-localize/README.md). Library
+provides helpers for dynamic strings that depends on current selected language.
+
+# How to use
+
+Build example with `cabal new-build -f examples`.
+
+First, you should define which languages your app supports:
+``` haskell
+module App.Language(
+    Language(..)
+  , module Reflex.Localize
+  ) where
+
+import Reflex.Localize
+import Reflex.Localize.Language
+
+data instance Language
+  = English
+  | Russian
+```
+
+Second, define enumeration for strings ids.
+
+``` haskell
+module App.Localization(
+    module App.Localization
+  , module App.Language
+  ) where
+
+import App.Language
+
+data AboutPageStrings =
+    AboutTitle
+  | AboutVersion
+  | AboutLicence
+  | AboutHomepage
+  | AboutDevelopers
+
+instance LocalizedPrint AboutPageStrings where
+  localizedShow l v = case l of
+    English -> case v of
+      AboutTitle      -> "About"
+      AboutVersion    -> "Version"
+      AboutLicence    -> "Licence"
+      AboutHomepage   -> "Homepage"
+      AboutDevelopers -> "Developers"
+    Russian -> case v of
+      AboutTitle      -> "О продукте"
+      AboutVersion    -> "Версия"
+      AboutLicence    -> "Лицензия"
+      AboutHomepage   -> "Сайт"
+      AboutDevelopers -> "Разработчики"
+```
+
+You can either collect all strings to one data sum or split strings for each
+widget.
+
+And finally you should implement `MonadLocalized` type class in you application monad.
+We suggest using monad transformer `LocalizeT` via `runLocalize` function:
+
+``` haskell
+runLocalize :: (Reflex t, TriggerEvent t m, MonadIO m) => Language -> LocalizeT t m a -> m a
+```
+
+Finally, you can define widgets with localization like following:
+``` haskell
+buttonClass :: (DomBuilder t m, PostBuild t m, MonadLocalized t m, LocalizedPrint lbl)
+  => Dynamic t Text -> lbl -> m (Event t ())
+buttonClass classValD lbl = mkButton "button" [("onclick", "return false;")] classValD . dynText =<< localized lbl
+
+mkButton :: (DomBuilder t m, PostBuild t m) => Text -> Map Text Text -> Dynamic t Text -> m a -> m (Event t a)
+mkButton eltp attrs classValD ma = do
+  let classesD = do
+        classVal <- classValD
+        pure $ attrs <> [("class", classVal)]
+  (e, a) <- elDynAttr' eltp classesD ma
+  return $ a <$ domEvent Click e
+```

--- a/reflex-localize-dom/example/App/Language.hs
+++ b/reflex-localize-dom/example/App/Language.hs
@@ -1,0 +1,21 @@
+module App.Language(
+    Language(..)
+  , module Reflex.Localize
+  ) where
+
+import Reflex.Localize
+import Reflex.Localize.Language
+
+data instance Language
+  = English
+  | Russian
+  deriving (Eq, Ord, Enum, Bounded)
+
+instance LocalizedPrint Language where
+  localizedShow l v = case l of
+    English -> case v of
+      English -> "English"
+      Russian -> "Russian"
+    Russian -> case v of
+      English -> "Английский"
+      Russian -> "Русский"

--- a/reflex-localize-dom/example/App/Localization.hs
+++ b/reflex-localize-dom/example/App/Localization.hs
@@ -1,0 +1,19 @@
+module App.Localization(
+    module App.Localization
+  , module App.Language
+  ) where
+
+import App.Language
+
+data AppStrings =
+    ButtonLabel
+  | PressedLabel
+
+instance LocalizedPrint AppStrings where
+  localizedShow l v = case l of
+    English -> case v of
+      ButtonLabel     -> "Button"
+      PressedLabel    -> "Button is pressed!"
+    Russian -> case v of
+      ButtonLabel     -> "Кнопка"
+      PressedLabel    -> "Кнопка нажата!"

--- a/reflex-localize-dom/example/Main.hs
+++ b/reflex-localize-dom/example/Main.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE QuasiQuotes #-}
+module Main where
+
+import App.Localization
+import Data.Map.Strict (Map)
+import Data.Text (Text)
+import Reflex.Dom
+import Reflex.Localize.Dom
+import Text.RawString.QQ
+
+main :: IO ()
+main = mainWidgetWithCss css $ runLocalize English $ do
+  languageDropdown
+  pressE <- buttonClass "outline" ButtonLabel
+  widgetHold_ (pure ()) $ localizedText PressedLabel <$ pressE
+  where
+    css = [r|
+      select {
+        background-color: white;
+        color: black;
+        font-size: 14pt;
+      }
+      .outline {
+        border-width: 1px;
+        border-radius: 10px;
+        min-width: 100px;
+        min-height: 50px;
+        margin-right: 30px;
+        color: black;
+        background-color: white;
+        border-color: black;
+        font-size: 14pt;
+      }
+    |]
+
+buttonClass :: (DomBuilder t m, PostBuild t m, MonadLocalized t m, LocalizedPrint lbl)
+  => Dynamic t Text -> lbl -> m (Event t ())
+buttonClass classValD lbl = mkButton "button" [("onclick", "return false;")] classValD . dynText =<< localized lbl
+
+mkButton :: (DomBuilder t m, PostBuild t m) => Text -> Map Text Text -> Dynamic t Text -> m a -> m (Event t a)
+mkButton eltp attrs classValD ma = do
+  let classesD = do
+        classVal <- classValD
+        pure $ attrs <> [("class", classVal)]
+  (e, a) <- elDynAttr' eltp classesD ma
+  return $ a <$ domEvent Click e

--- a/reflex-localize-dom/ghcid.sh
+++ b/reflex-localize-dom/ghcid.sh
@@ -1,0 +1,1 @@
+ghcid -c "cabal new-repl"

--- a/reflex-localize-dom/reflex-localize-dom.cabal
+++ b/reflex-localize-dom/reflex-localize-dom.cabal
@@ -1,8 +1,7 @@
-name:                reflex-localize
+name:                reflex-localize-dom
 version:             1.0.0.0
-synopsis:            Localization library for reflex
+synopsis:            Helper widgets for reflex-localize
 description:         Library provides helpers for dynamic strings that depends on current selected language.
-  See also `reflex-localize-dom` for examples and DOM related helpers.
 stability:           Experimental
 category:            Reflex, FRP, Web, GUI, HTML, Javascript, Reactive, Reactivity, User Interfaces, User-interface
 build-type:          Simple
@@ -25,36 +24,83 @@ extra-source-files:
   README.md
   CHANGELOG.md
 
+flag examples
+  default: False
+  manual: True
+
 library
   hs-source-dirs:      src
   exposed-modules:
-    Reflex.Localize
-    Reflex.Localize.Class
-    Reflex.Localize.Language
-    Reflex.Localize.Monad
-    Reflex.Localize.Trans
+    Reflex.Localize.Dom
   build-depends:
       base                      >= 4.5      && < 4.15
-    , jsaddle
-    , mtl
-    , reflex                    >= 0.4      && < 0.8
-    , reflex-external-ref
+    , containers
+    , reflex                    >= 0.4      && < 0.9
+    , reflex-dom                >= 0.6      && < 0.9
+    , reflex-localize           >= 1.0      && < 1.1
     , text
   default-language:    Haskell2010
   default-extensions:
     DataKinds
     DeriveDataTypeable
     DeriveGeneric
+    FlexibleContexts
     FlexibleInstances
     FunctionalDependencies
     GeneralizedNewtypeDeriving
     LambdaCase
     MultiParamTypeClasses
+    OverloadedStrings
     RankNTypes
     ScopedTypeVariables
     StandaloneDeriving
     TypeFamilies
     UndecidableInstances
+
+executable reflex-localize-example
+  hs-source-dirs: example
+  if flag(examples)
+    buildable: True
+  else
+    buildable: False
+  main-is:             Main.hs
+  other-modules:
+    App.Language
+    App.Localization
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      base
+    , containers
+    , raw-strings-qq
+    , reflex
+    , reflex-dom
+    , reflex-localize
+    , reflex-localize-dom
+    , text
+
+  default-language:    Haskell2010
+  default-extensions:
+    BangPatterns
+    ConstraintKinds
+    DataKinds
+    DeriveDataTypeable
+    DeriveGeneric
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    GADTs
+    GeneralizedNewtypeDeriving
+    LambdaCase
+    OverloadedStrings
+    RankNTypes
+    RecordWildCards
+    ScopedTypeVariables
+    StandaloneDeriving
+    TemplateHaskell
+    TupleSections
+    TypeApplications
+    TypeFamilies
+    TypeOperators
 
 source-repository head
   type: git

--- a/reflex-localize-dom/reflex-localize-dom.cabal
+++ b/reflex-localize-dom/reflex-localize-dom.cabal
@@ -5,7 +5,7 @@ description:         Library provides helpers for dynamic strings that depends o
 stability:           Experimental
 category:            Reflex, FRP, Web, GUI, HTML, Javascript, Reactive, Reactivity, User Interfaces, User-interface
 build-type:          Simple
-cabal-version:       >= 1.25
+cabal-version:       >=1.10
 license:             MIT
 license-file:        LICENSE
 copyright:           2019 ATUM SOLUTIONS AG

--- a/reflex-localize-dom/src/Reflex/Localize/Dom.hs
+++ b/reflex-localize-dom/src/Reflex/Localize/Dom.hs
@@ -1,0 +1,61 @@
+-- |
+-- Module      : Reflex.Localize.Dom
+-- Copyright   : (c) 2019-2020 ATUM SOLUTIONS AG
+-- License     : MIT
+-- Maintainer  : ncrashed@protonmail.com
+-- Stability   : unstable
+-- Portability : non-portable
+--
+-- Dom helpers to show localized
+--
+module Reflex.Localize.Dom(
+    localizedText
+  , localizedTextWith
+  , localizedTextLower
+  , localizedTextUpper
+  , languageDropdown
+  , module Reflex.Localize
+  ) where
+
+import Control.Monad.Fix
+import Data.Text (Text)
+import Reflex.Dom
+import Reflex.Localize
+import Reflex.Localize.Language
+import Reflex.Localize.Trans
+
+import qualified Data.Text as T
+import qualified Data.Map.Strict as M
+
+-- | Simple dropdown that allows to select a language and set it for current context. The dropdown has `select-lang` CSS class.
+languageDropdown :: (MonadLocalized t m, MonadFix m, PostBuild t m, MonadHold t m, DomBuilder t m, LocalizedPrint Language, Eq Language, Enum Language, Ord Language, Bounded Language) => m ()
+languageDropdown = do
+  langD <- getLanguage
+  initKey <- sample . current $ langD
+  let listLangsD = ffor langD $ \l -> M.fromList $ fmap (\v -> (v, localizedShow l v)) [minBound .. maxBound]
+      ddnCfg = DropdownConfig {
+            _dropdownConfig_setValue   = updated langD
+          , _dropdownConfig_attributes = constDyn ("class" =: "select-lang")
+          }
+  dp <- dropdown initKey listLangsD ddnCfg
+  let selD = _dropdown_value dp
+  selE <- fmap updated $ holdUniqDyn selD
+  widgetHold_ (pure ()) $ setLanguage <$> selE
+
+-- | Same as 'text', but changes when language is changed.
+localizedText :: (MonadLocalized t m, LocalizedPrint a, PostBuild t m, DomBuilder t m) => a -> m ()
+localizedText val = dynText =<< localized val
+
+-- | Same as `localizedText` but transforms text before displaying.
+localizedTextWith :: (MonadLocalized t m, LocalizedPrint a, PostBuild t m, DomBuilder t m) => (Text -> Text) -> a -> m ()
+localizedTextWith f val = dynText =<< ((fmap . fmap) f $ localized val)
+
+-- | Same as `localizedText` but transforms text to lower case.
+localizedTextLower :: (MonadLocalized t m, LocalizedPrint a, PostBuild t m, DomBuilder t m) => a -> m ()
+localizedTextLower = localizedTextWith T.toLower
+
+-- | Same as `localizedText` but transforms text to upper case.
+localizedTextUpper :: (MonadLocalized t m, LocalizedPrint a, PostBuild t m, DomBuilder t m) => a -> m ()
+localizedTextUpper = localizedTextWith T.toUpper
+
+deriving instance DomBuilder t m => DomBuilder t (LocalizeT t m)

--- a/reflex-localize-dom/upload-docs.sh
+++ b/reflex-localize-dom/upload-docs.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -xe
+
+rm ../dist-newstyle/reflex-localize-dom-*-docs.tar.gz || true
+
+# assumes cabal 2.4 or later
+cabal v2-haddock --haddock-for-hackage --enable-doc
+
+cabal upload -d --publish ../dist-newstyle/reflex-localize-dom-*.tar.gz

--- a/reflex-localize-dom/upload.sh
+++ b/reflex-localize-dom/upload.sh
@@ -1,0 +1,4 @@
+set -xe
+rm ../dist-newstyle/sdist -rf | true
+cabal new-sdist
+cabal upload --publish ../dist-newstyle/sdist/reflex-localize-dom-*.tar.gz

--- a/reflex-localize/CHANGELOG.md
+++ b/reflex-localize/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 1.0.0.0
+
+* Initial release

--- a/reflex-localize/README.md
+++ b/reflex-localize/README.md
@@ -1,0 +1,64 @@
+# reflex-localize
+
+Library provides helpers for dynamic strings that depends on current selected
+language.
+
+# How to use
+
+First, you should define which languages your app supports:
+``` haskell
+module App.Language(
+    Language(..)
+  , module Reflex.Localize
+  ) where
+
+import Reflex.Localize
+import Reflex.Localize.Language
+
+data instance Language
+  = English
+  | Russian
+```
+
+Second, define enumeration for strings ids.
+
+``` haskell
+module App.Localization(
+    module App.Localization
+  , module App.Language
+  ) where
+
+import App.Language
+
+data AboutPageStrings =
+    AboutTitle
+  | AboutVersion
+  | AboutLicence
+  | AboutHomepage
+  | AboutDevelopers
+
+instance LocalizedPrint AboutPageStrings where
+  localizedShow l v = case l of
+    English -> case v of
+      AboutTitle      -> "About"
+      AboutVersion    -> "Version"
+      AboutLicence    -> "Licence"
+      AboutHomepage   -> "Homepage"
+      AboutDevelopers -> "Developers"
+    Russian -> case v of
+      AboutTitle      -> "О продукте"
+      AboutVersion    -> "Версия"
+      AboutLicence    -> "Лицензия"
+      AboutHomepage   -> "Сайт"
+      AboutDevelopers -> "Разработчики"
+```
+
+You can either collect all strings to one data sum or split strings for each
+widget.
+
+Finally, you should implement `MonadLocalized` type class in you application monad.
+We suggest using monad transformer `LocalizeT` via `runLocalize` function:
+
+``` haskell
+runLocalize :: (Reflex t, TriggerEvent t m, MonadIO m) => Language -> LocalizeT t m a -> m a
+```

--- a/reflex-localize/reflex-localize.cabal
+++ b/reflex-localize/reflex-localize.cabal
@@ -6,7 +6,7 @@ description:         Library provides helpers for dynamic strings that depends o
 stability:           Experimental
 category:            Reflex, FRP, Web, GUI, HTML, Javascript, Reactive, Reactivity, User Interfaces, User-interface
 build-type:          Simple
-cabal-version:       >= 1.25
+cabal-version:       >=1.10
 license:             MIT
 license-file:        LICENSE
 copyright:           2019 ATUM SOLUTIONS AG

--- a/reflex-localize/reflex-localize.cabal
+++ b/reflex-localize/reflex-localize.cabal
@@ -28,7 +28,7 @@ library
     Reflex.Localize.Monad
     Reflex.Localize.Trans
   build-depends:
-      base
+      base                      >= 4.5      && < 4.15
     , text
     , reflex                    >= 0.4      && < 0.7
     , reflex-dom                >= 0.4      && < 0.7

--- a/reflex-localize/src/Reflex/Localize/Class.hs
+++ b/reflex-localize/src/Reflex/Localize/Class.hs
@@ -3,9 +3,6 @@ module Reflex.Localize.Class(
     GrammarCase(..)
   , LocalizedPrint(..)
   , defaultLocPrintDyn
-  , localizedText
-  , localizedTextLower
-  , localizedTextUpper
 ) where
 
 import Data.Data
@@ -14,7 +11,6 @@ import Data.Text (Text)
 import GHC.Generics
 import qualified Data.Text as T
 import Reflex
-import Reflex.Dom
 import Reflex.Localize.Language
 import Reflex.Localize.Monad
 
@@ -62,18 +58,3 @@ instance (LocalizedPrint a, LocalizedPrint b) => LocalizedPrint (Either a b) whe
 -- | Default implementation
 defaultLocPrintDyn :: MonadLocalized t m => (Language -> a -> Text) -> a -> m (Dynamic t Text)
 defaultLocPrintDyn f v = fmap (fmap (flip f v)) getLanguage
-
-localizedText :: (MonadLocalized t m, LocalizedPrint a) => a -> m ()
-localizedText val = dynText =<< localized val
-
-localizedTextLower :: (MonadLocalized t m, LocalizedPrint a) => a -> m ()
-localizedTextLower val = dynText =<< (fmap2 T.toLower $ localized val)
-  where
-    fmap2 :: (Functor f, Functor g) => (a -> b) -> f (g a) -> f (g b)
-    fmap2 f x = fmap (fmap f) x
-
-localizedTextUpper :: (MonadLocalized t m, LocalizedPrint a) => a -> m ()
-localizedTextUpper val = dynText =<< (fmap2 T.toUpper $ localized val)
-  where
-    fmap2 :: (Functor f, Functor g) => (a -> b) -> f (g a) -> f (g b)
-    fmap2 f x = fmap (fmap f) x

--- a/reflex-localize/src/Reflex/Localize/Monad.hs
+++ b/reflex-localize/src/Reflex/Localize/Monad.hs
@@ -5,7 +5,6 @@ module Reflex.Localize.Monad
 
 import Control.Monad.Reader
 import Reflex
-import Reflex.Dom
 import Reflex.Localize.Language
 
 -- | ===========================================================================
@@ -13,7 +12,7 @@ import Reflex.Localize.Language
 -- | ===========================================================================
 
 -- | API for language localization support
-class (Reflex t, Monad m, PostBuild t m, DomBuilder t m) => MonadLocalized t m | m -> t where
+class (Reflex t, Monad m) => MonadLocalized t m | m -> t where
   -- | Switch frontend language
   setLanguage :: Language -> m ()
   -- | Switch frontend language by event

--- a/reflex-localize/src/Reflex/Localize/Trans.hs
+++ b/reflex-localize/src/Reflex/Localize/Trans.hs
@@ -15,7 +15,6 @@ import Control.Monad.State.Strict
 import GHC.Generics
 import Language.Javascript.JSaddle.Types
 import Reflex
-import Reflex.Dom
 import Reflex.ExternalRef
 import Reflex.Localize.Language
 import Reflex.Localize.Monad
@@ -38,7 +37,6 @@ deriving instance PerformEvent t m => PerformEvent t (LocalizeT t m)
 deriving instance TriggerEvent t m => TriggerEvent t (LocalizeT t m)
 deriving instance MonadHold t m => MonadHold t (LocalizeT t m)
 deriving instance MonadSample t m => MonadSample t (LocalizeT t m)
-deriving instance DomBuilder t m => DomBuilder t (LocalizeT t m)
 deriving instance MonadIO m => MonadIO (LocalizeT t m)
 deriving instance MonadJSM m => MonadJSM (LocalizeT t m)
 deriving instance (Group q, Additive q, Query q, Eq q, MonadQuery t q m, Monad m) => MonadQuery t q (LocalizeT t m)
@@ -95,7 +93,7 @@ runLocalize initLang ma = do
   runLocalizeT ma re
 {-# INLINABLE runLocalize #-}
 
-instance (PerformEvent t m, MonadHold t m, Adjustable t m, MonadFix m, MonadIO (Performable m), PostBuild t m, MonadIO m, DomBuilder t m)
+instance (PerformEvent t m, MonadHold t m, Adjustable t m, MonadFix m, MonadIO (Performable m), PostBuild t m, MonadIO m)
   => MonadLocalized t (LocalizeT t m) where
   setLanguage lang = do
     langRef <- LocalizeT $ asks locEnvLangRef

--- a/reflex-localize/upload-docs.sh
+++ b/reflex-localize/upload-docs.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 set -xe
 
-rm ../dist-newstyle/reflex-external-ref-*-docs.tar.gz
+rm ../dist-newstyle/reflex-localize-*-docs.tar.gz || true
 
 # assumes cabal 2.4 or later
 cabal v2-haddock --haddock-for-hackage --enable-doc
 
-cabal upload -d --publish ../dist-newstyle/reflex-external-ref-*.tar.gz
+cabal upload -d --publish ../dist-newstyle/reflex-localize-*.tar.gz

--- a/reflex-localize/upload-docs.sh
+++ b/reflex-localize/upload-docs.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -xe
+
+rm ../dist-newstyle/reflex-external-ref-*-docs.tar.gz
+
+# assumes cabal 2.4 or later
+cabal v2-haddock --haddock-for-hackage --enable-doc
+
+cabal upload -d --publish ../dist-newstyle/reflex-external-ref-*.tar.gz

--- a/reflex-localize/upload.sh
+++ b/reflex-localize/upload.sh
@@ -1,4 +1,4 @@
 set -xe
 rm ../dist-newstyle/sdist -rf | true
 cabal new-sdist
-cabal upload --publish ../dist-newstyle/sdist/reflex-external-ref-*.tar.gz
+cabal upload --publish ../dist-newstyle/sdist/reflex-localize-*.tar.gz

--- a/reflex-localize/upload.sh
+++ b/reflex-localize/upload.sh
@@ -1,0 +1,4 @@
+set -xe
+rm ../dist-newstyle/sdist -rf | true
+cabal new-sdist
+cabal upload --publish ../dist-newstyle/sdist/reflex-external-ref-*.tar.gz

--- a/retractable/reflex-dom-retractable.cabal
+++ b/retractable/reflex-dom-retractable.cabal
@@ -23,7 +23,7 @@ library
     Reflex.Dom.Retractable.Trans
     Reflex.Dom.Retractable.Trans.Internal
   build-depends:
-      base                 >= 4.7      && < 4.13
+      base                 >= 4.7      && < 4.15
     , containers           >= 0.5      && < 0.7
     , jsaddle              >= 0.9      && < 0.10
     , mtl                  >= 2.1      && < 2.3

--- a/wallet/ergvein-wallet.cabal
+++ b/wallet/ergvein-wallet.cabal
@@ -212,6 +212,7 @@ library
         reflex-dom-retractable -any,
         reflex-external-ref -any,
         reflex-localize -any,
+        reflex-localize-dom -any,
         safe -any,
         safe-exceptions -any,
         semialign -any,

--- a/wallet/src/Ergvein/Wallet/Elements/Inplace.hs
+++ b/wallet/src/Ergvein/Wallet/Elements/Inplace.hs
@@ -50,7 +50,7 @@ instance (Reflex t, LocalizedPrint lbl) => Default (InplaceEditCfg t (InplaceEdi
 
 -- | Generic widget to edit a single field value inplace. Text label with a edit button aside.
 -- On edit label is replaced with text field and save/delete/cancel buttons below.
-inplaceEditField :: forall t m a lbl . (DomBuilder t m, MonadFix m, MonadHold t m, MonadLocalized t m, LocalizedPrint lbl)
+inplaceEditField :: forall t m a lbl . (DomBuilder t m, PostBuild t m, MonadFix m, MonadHold t m, MonadLocalized t m, LocalizedPrint lbl)
   => InplaceEditCfg t lbl -- ^ Configuration of widget
   -> (a -> Text) -- ^ Render value to text
   -> (Text -> Either lbl a) -- ^ Parse value from text

--- a/wallet/src/Ergvein/Wallet/Elements/Input.hs
+++ b/wallet/src/Ergvein/Wallet/Elements/Input.hs
@@ -29,6 +29,7 @@ import Ergvein.Wallet.Elements.Input.Class
 import Ergvein.Wallet.Id
 import Ergvein.Wallet.Monad
 import Reflex.Localize
+import Reflex.Localize.Dom
 
 import qualified Data.Map.Strict as M
 

--- a/wallet/src/Ergvein/Wallet/Elements/Toggle.hs
+++ b/wallet/src/Ergvein/Wallet/Elements/Toggle.hs
@@ -14,7 +14,7 @@ import Ergvein.Wallet.Language
 import Ergvein.Wallet.Util
 
 -- | Create toggle button with pressed and unpressed states
-toggleButton :: forall t m lbl . (DomBuilder t m, MonadHold t m, MonadLocalized t m, MonadFix m, LocalizedPrint lbl)
+toggleButton :: forall t m lbl . (DomBuilder t m, PostBuild t m, MonadHold t m, MonadLocalized t m, MonadFix m, LocalizedPrint lbl)
   => lbl -- ^ Label of button unpressed
   -> lbl -- ^ Label of button pressed
   -> Dynamic t Bool -- ^ Input of toggler
@@ -30,7 +30,7 @@ toggleButton lblOff lblOn val0D = mdo
   pure valD'
 
 -- | Toggler switch with alya materlized looking
-toggler :: (DomBuilder t m, MonadSample t m, MonadIO m, MonadLocalized t m, LocalizedPrint l)
+toggler :: (DomBuilder t m, PostBuild t m, MonadSample t m, MonadIO m, MonadLocalized t m, LocalizedPrint l)
   => l
   -> (Dynamic t Bool)
   -> m  (Dynamic t Bool)

--- a/wallet/src/Ergvein/Wallet/Language.hs
+++ b/wallet/src/Ergvein/Wallet/Language.hs
@@ -4,11 +4,13 @@ module Ergvein.Wallet.Language(
     Language(..)
   , allLanguages
   , module Reflex.Localize
+  , module Reflex.Localize.Dom
   ) where
 
 import Ergvein.Aeson
 import GHC.Generics (Generic)
 import Reflex.Localize
+import Reflex.Localize.Dom
 import Reflex.Localize.Language
 
 -- | Languages that are supported by wallet

--- a/wallet/src/Ergvein/Wallet/Navbar.hs
+++ b/wallet/src/Ergvein/Wallet/Navbar.hs
@@ -28,7 +28,7 @@ navbarWidget cur prevWidget activeItem = do
         divClass "navbar-balance" $ dynText balance
         divClass "navbar-status"  $ syncWidget False cur
 
-navbarBtn :: (DomBuilder t m, MonadLocalized t m) => NavbarItem -> NavbarItem-> m (Event t NavbarItem)
+navbarBtn :: (DomBuilder t m, PostBuild t m, MonadLocalized t m) => NavbarItem -> NavbarItem-> m (Event t NavbarItem)
 navbarBtn item activeItem
   | item == activeItem = (item <$) <$> spanButton "navbar-item active" item
   | item /= activeItem = (item <$) <$> spanButton "navbar-item" item

--- a/wallet/src/Ergvein/Wallet/Page/Currencies.hs
+++ b/wallet/src/Ergvein/Wallet/Page/Currencies.hs
@@ -6,7 +6,7 @@ module Ergvein.Wallet.Page.Currencies(
 
 import Data.List (find)
 import Data.Maybe (fromMaybe)
-import Reflex.Localize
+import Reflex.Localize.Dom
 
 import Ergvein.Crypto.Keys
 import Ergvein.Text

--- a/wallet/src/Ergvein/Wallet/Page/Password.hs
+++ b/wallet/src/Ergvein/Wallet/Page/Password.hs
@@ -180,7 +180,7 @@ changePasswordDescWidget = wrapperSimple True $ mdo
       pure (passE, True <$ emptyE)
   pure $ (,True) <$> passE
 
-changePasswordDescr :: MonadLocalized t m => Bool -> m ()
+changePasswordDescr :: (MonadLocalized t m, DomBuilder t m, PostBuild t m) => Bool -> m ()
 changePasswordDescr b = do
   divClass "password-setup-title" $ h4 $ localizedText (b, CPSTitle)
   divClass "password-setup-descr" $ h5 $ localizedText (b, CPSDescr)

--- a/wallet/src/Ergvein/Wallet/Page/Seed.hs
+++ b/wallet/src/Ergvein/Wallet/Page/Seed.hs
@@ -34,7 +34,7 @@ import Ergvein.Wallet.Resize
 import Ergvein.Wallet.Storage.Util
 import Ergvein.Wallet.Validate
 import Ergvein.Wallet.Wrapper
-import Reflex.Localize
+import Reflex.Localize.Dom
 
 import qualified Data.List      as L
 import qualified Data.Serialize as S

--- a/wallet/src/Ergvein/Wallet/Password.hs
+++ b/wallet/src/Ergvein/Wallet/Password.hs
@@ -26,7 +26,7 @@ import Ergvein.Wallet.Page.PatternKey
 import Ergvein.Wallet.Platform
 import Ergvein.Wallet.Storage.Util
 import Ergvein.Wallet.Validate
-import Reflex.Localize
+import Reflex.Localize.Dom
 import qualified Data.Text as T
 
 import Control.Monad.IO.Class


### PR DESCRIPTION
Published:
- `reflex-external-ref`
- `reflex-localize`
- `reflex-localize-dom` 

I moved `reflex-dom` related parts from `reflex-localize` to `reflex-localize-dom`