### PR TITLE
Warning and misc. changes

### DIFF
--- a/crypto/ergvein-crypto.cabal
+++ b/crypto/ergvein-crypto.cabal
@@ -46,7 +46,7 @@ library
     , secp256k1-haskell         >= 0.2.2    && < 0.2.3
     , string-conversions        >= 0.4.0.1  && <0.4.0.2
     , text                      >= 1.2      && < 1.3
-    , vector                    >= 0.10     && < 0.12.1
+    , vector                    >= 0.10     && < 0.13
   default-language:    Haskell2010
   default-extensions:
     GADTs

--- a/index-server/ergvein-index-server.cabal
+++ b/index-server/ergvein-index-server.cabal
@@ -129,6 +129,9 @@ library
   default-extensions:
     BangPatterns
     DataKinds
+    DeriveFunctor
+    DeriveFoldable
+    DeriveTraversable
     DeriveDataTypeable
     DeriveGeneric
     FlexibleContexts

--- a/index-server/src/Ergvein/Index/Server/DB.hs
+++ b/index-server/src/Ergvein/Index/Server/DB.hs
@@ -8,16 +8,12 @@ module Ergvein.Index.Server.DB
 import Conduit
 import Control.Exception
 import Control.Monad
-import Control.Monad.Catch
 import Control.Monad.Logger
 import Data.Default
 import Database.LevelDB.Base
-import Database.LevelDB.Internal
 import System.Directory
-import System.FilePath
 
 import Ergvein.Index.Server.DB.Monad
-import Ergvein.Index.Server.DB.Queries (initIndexerDb)
 
 import qualified Ergvein.Index.Server.DB.Schema.Filters as DBF
 import qualified Ergvein.Index.Server.DB.Schema.Indexer as DBI

--- a/index-server/src/Ergvein/Index/Server/Monad.hs
+++ b/index-server/src/Ergvein/Index/Server/Monad.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DerivingVia #-}
 module Ergvein.Index.Server.Monad where
 
 import Control.Concurrent.STM
@@ -22,11 +23,9 @@ import qualified Data.Map.Strict as M
 import qualified Network.Ergo.Api.Client     as ErgoApi
 
 newtype ServerM a = ServerM { unServerM :: ReaderT ServerEnv (LoggingT IO) a }
-  deriving (Functor, Applicative, Monad, MonadIO, MonadLogger, MonadReader ServerEnv, MonadThrow, MonadCatch, MonadMask, MonadBase IO, MonadMonitor)
-
-instance MonadMonitor m => MonadMonitor (LoggingT m) where
-  doIO = lift . doIO
-  {-# INLINE doIO #-}
+  deriving (Functor, Applicative, Monad, MonadIO, MonadLogger, MonadReader ServerEnv, MonadThrow, MonadCatch, MonadMask, MonadBase IO)
+  -- To avoid orphan we unwrap LoggingT as its reader representation
+  deriving MonadMonitor via (ReaderT ServerEnv (ReaderT (Loc -> LogSource -> LogLevel -> LogStr -> IO ()) IO))
 
 newtype StMServerM a = StMServerM { unStMServerM :: StM (ReaderT ServerEnv (LoggingT IO)) a }
 


### PR DESCRIPTION
1. Adds DervingFunctor&Co extensions to cabal. Aren't used but nice to have at hand
2. Bump vector constraints on vector for ergvein-crypto to make it buildable together with hschain
3. Fix all warnings that doesn't mask some possible bug: unhandled case, unused ThreadId. Latter means that there's likely possibility to leak threads.