### PR TITLE
Idx server improve

### DIFF
--- a/index-server/src/Ergvein/Index/Server/BlockchainScanning/Bitcoin.hs
+++ b/index-server/src/Ergvein/Index/Server/BlockchainScanning/Bitcoin.hs
@@ -89,7 +89,7 @@ actualHeight = fromIntegral <$> nodeRpcCall getBlockCount
 getTxFromCache :: (HasFiltersDB m, MonadLogger m)
   => TxHash -> m (Either String HK.Tx)
 getTxFromCache thash = do
-  db <- getFiltersDb
+  db <- readFiltersDb
   msrc <- getParsed BTC "getTxFromCache" db $ txBytesKey thash
   pure $ case msrc of
     Nothing -> Left $ "Tx not found. TxHash: " <> show thash
@@ -98,7 +98,7 @@ getTxFromCache thash = do
 getTxFromNode :: (BitcoinApiMonad m, MonadLogger m, MonadBaseControl IO m, HasFiltersDB m)
   => HK.TxHash -> m HK.Tx
 getTxFromNode thash = do
-  db <- getFiltersDb
+  db <- readFiltersDb
   txHeight <- fmap unTxRecHeight $
     getParsedExact BTC "getTxFromNode" db $ txHeightKey $ hkTxHashToEgv thash
   blk <- getBtcBlock $ fromIntegral txHeight

--- a/index-server/src/Ergvein/Index/Server/BlockchainScanning/Bitcoin.hs
+++ b/index-server/src/Ergvein/Index/Server/BlockchainScanning/Bitcoin.hs
@@ -90,8 +90,10 @@ getTxFromCache :: (HasFiltersDB m, MonadLogger m)
   => TxHash -> m (Either String HK.Tx)
 getTxFromCache thash = do
   db <- getFiltersDb
-  src <- getParsedExact BTC "getTxFromCache" db $ txBytesKey thash
-  pure $ egvDeserialize BTC $ unTxRecBytes src
+  msrc <- getParsed BTC "getTxFromCache" db $ txBytesKey thash
+  pure $ case msrc of
+    Nothing -> Left $ "Tx not found. TxHash: " <> show thash
+    Just src -> egvDeserialize BTC $ unTxRecBytes src
 
 getTxFromNode :: (BitcoinApiMonad m, MonadLogger m, MonadBaseControl IO m, HasFiltersDB m)
   => HK.TxHash -> m HK.Tx

--- a/index-server/src/Ergvein/Index/Server/DB/Queries.hs
+++ b/index-server/src/Ergvein/Index/Server/DB/Queries.hs
@@ -58,7 +58,8 @@ getActualPeers :: (HasIndexerDB m, MonadLogger m, HasDiscoveryRequisites m) =>  
 getActualPeers = do
   db <- getIndexerDb
   -- I put BTC here and downstream, because it doesnt actually matter but we still need a value
-  knownPeers <- getParsedExact @KnownPeersRec Currency.BTC "getKnownPeers" db knownPeersRecKey
+  mKnownPeers <- getParsed Currency.BTC "getKnownPeers" db knownPeersRecKey
+  let knownPeers = fromMaybe (KnownPeersRec []) mKnownPeers
   currentTime <- liftIO getCurrentTime
   actualizationDelay <- (/1000000) . fromIntegral . descReqActualizationDelay <$> getDiscoveryRequisites
   let validDate = (-actualizationDelay) `addUTCTime` currentTime

--- a/index-server/src/Ergvein/Index/Server/DB/Queries.hs
+++ b/index-server/src/Ergvein/Index/Server/DB/Queries.hs
@@ -56,7 +56,7 @@ import qualified Database.LevelDB as LDB
 
 getActualPeers :: (HasIndexerDB m, MonadLogger m, HasDiscoveryRequisites m) =>  m [Address]
 getActualPeers = do
-  db <- getIndexerDb
+  db <- readIndexerDb
   -- I put BTC here and downstream, because it doesnt actually matter but we still need a value
   mKnownPeers <- getParsed Currency.BTC "getKnownPeers" db knownPeersRecKey
   let knownPeers = fromMaybe (KnownPeersRec []) mKnownPeers
@@ -71,7 +71,7 @@ getPeerList = fmap (fmap convert . unKnownPeersRec) peerList
 
 setPeerList :: (HasIndexerDB m, MonadLogger m) => [Peer] -> m ()
 setPeerList peers = do
-  idb <- getIndexerDb
+  idb <- readIndexerDb
   upsertItem Currency.BTC  idb knownPeersRecKey $ KnownPeersRec $ convert @_ @KnownPeerRecItem <$> peers
 
 upsertPeer :: (HasIndexerDB m, MonadLogger m) => Peer -> m ()
@@ -82,13 +82,13 @@ upsertPeer peer = do
 
 peerList :: (HasIndexerDB m, MonadLogger m) => m KnownPeersRec
 peerList = do
-  idb <- getIndexerDb
+  idb <- readIndexerDb
   maybeLst <- getParsed @KnownPeersRec Currency.BTC "getKnownPeersList"  idb knownPeersRecKey
   pure $ fromMaybe (KnownPeersRec mempty) maybeLst
 
 setPeerRecList :: (HasIndexerDB m, MonadLogger m) => KnownPeersRec -> m ()
 setPeerRecList peers = do
-  idb <- getIndexerDb
+  idb <- readIndexerDb
   upsertItem Currency.BTC idb knownPeersRecKey peers
 
 deletePeerBySockAddr :: (HasIndexerDB m, MonadLogger m) => PeerAddr -> m ()
@@ -104,13 +104,13 @@ emptyKnownPeers = setPeerRecList $ KnownPeersRec []
 
 getScannedHeight :: (HasFiltersDB m, MonadLogger m) => Currency -> m (Maybe BlockHeight)
 getScannedHeight currency = do
-  db <- getFiltersDb
+  db <- readFiltersDb
   stored <- getParsed currency "BlockHeight" db $ scannedHeightTxKey currency
   pure $ scannedHeightRecHeight <$> stored
 
 setScannedHeight :: (HasFiltersDB m, MonadLogger m) => Currency -> BlockHeight -> m ()
 setScannedHeight currency height = do
-  db <- getFiltersDb
+  db <- readFiltersDb
   upsertItem currency db (scannedHeightTxKey currency) $ ScannedHeightRec height
 
 initIndexerDb :: DB -> IO ()
@@ -119,7 +119,7 @@ initIndexerDb db = do
 
 addBlockInfo :: (HasBtcRollback m, HasFiltersDB m, HasIndexerDB m, MonadLogger m, MonadBaseControl IO m) => BlockInfo -> m ()
 addBlockInfo (BlockInfo meta spent txinfos) = do
-  db <- getFiltersDb
+  db <- readFiltersDb
   write db def $ txInfosBatch <> metaInfosBatch <> heightWrite
   insertRollback cur $ RollbackRecItem txHashes prevHash (height -1)
   insertSpentTxUpdates cur spent
@@ -133,19 +133,19 @@ addBlockInfo (BlockInfo meta spent txinfos) = do
 
 setLastScannedBlock :: (HasIndexerDB m, MonadLogger m) => Currency -> ShortByteString -> m ()
 setLastScannedBlock currency blockHash = do
-  db <- getIndexerDb
+  db <- readIndexerDb
   upsertItem currency db (lastScannedBlockHeaderHashRecKey currency) $ LastScannedBlockHeaderHashRec blockHash
 
 getLastScannedBlock :: (HasIndexerDB m, MonadLogger m) => Currency -> m (Maybe ShortByteString)
 getLastScannedBlock currency = do
-  db <- getIndexerDb
+  db <- readIndexerDb
   maybeLastScannedBlock <- getParsed currency "lastScannedBlockHeaderHashRecKey" db $ lastScannedBlockHeaderHashRecKey currency
   pure $ lastScannedBlockHeaderHashRecHash <$> maybeLastScannedBlock
 
 -- Currency should be consistent with currency in BlockInfoMeta
 addBlockMetaInfos :: (HasFiltersDB m, MonadLogger m) => Currency -> [BlockMetaInfo] -> m ()
 addBlockMetaInfos currency infos = do
-  db <- getFiltersDb
+  db <- readFiltersDb
   write db def $ putItems currency keySelector valueSelector infos
   where
     keySelector   info = metaRecKey (blockMetaCurrency info, blockMetaBlockHeight info)
@@ -174,18 +174,18 @@ insertBtcRollback ritem = do
 
 storeRollbackSequence :: (HasIndexerDB m, MonadLogger m) => Currency -> RollbackSequence -> m ()
 storeRollbackSequence cur rse = do
-  idb <- getIndexerDb
+  idb <- readIndexerDb
   write idb def $ pure $ LDB.Put (rollbackKey cur) $ egvSerialize cur rse
 
 loadRollbackSequence :: (HasIndexerDB m, MonadLogger m) => Currency -> m RollbackSequence
 loadRollbackSequence cur = do
-  idb <- getIndexerDb
+  idb <- readIndexerDb
   mseq <- getParsed cur "loadRollbackSequence" idb $ rollbackKey cur
   pure $ fromMaybe (RollbackSequence mempty) mseq
 
 insertSpentTxUpdates :: (HasFiltersDB m, MonadLogger m, MonadBaseControl IO m) => Currency -> Map.Map TxHash Word32 -> m ()
 insertSpentTxUpdates _ outs = do
-  fdb <- getFiltersDb
+  fdb <- readFiltersDb
   let outsl = mkChunks 100 $ Map.toList outs
   upds <- fmap (mconcat . mconcat) $ mapConcurrently (traverse (mkupds fdb)) outsl
   write fdb def upds
@@ -208,8 +208,8 @@ performRollback cur = case cur of
 performBtcRollback :: (HasFiltersDB m, HasIndexerDB m, HasBtcRollback m, MonadLogger m) => m Int
 performBtcRollback = do
   let cur = Currency.BTC
-  fdb <- getIndexerDb
-  idb <- getFiltersDb
+  fdb <- readIndexerDb
+  idb <- readFiltersDb
   rollVar <- getBtcRollbackVar
   rse <- liftIO . readTVarIO $ rollVar
   let clearSeq = LDB.Put (rollbackKey cur) $ egvSerialize cur (RollbackSequence mempty)

--- a/index-server/src/Ergvein/Index/Server/Monad.hs
+++ b/index-server/src/Ergvein/Index/Server/Monad.hs
@@ -38,12 +38,12 @@ runServerMIO :: ServerEnv -> ServerM a -> IO a
 runServerMIO e = runChanLoggingT (envLogger e) . flip runReaderT e . unServerM
 
 instance HasFiltersDB ServerM where
-  getFiltersDb = asks envFiltersDBContext
-  {-# INLINE getFiltersDb #-}
+  getFiltersDbVar = asks envFiltersDBContext
+  {-# INLINE getFiltersDbVar #-}
 
 instance HasIndexerDB ServerM where
-  getIndexerDb = asks envIndexerDBContext
-  {-# INLINE getIndexerDb #-}
+  getIndexerDbVar = asks envIndexerDBContext
+  {-# INLINE getIndexerDbVar #-}
 
 instance HasBtcRollback ServerM where
   getBtcRollbackVar = asks envBtcRollback

--- a/index-server/src/Ergvein/Index/Server/TCPService/MessageHandler.hs
+++ b/index-server/src/Ergvein/Index/Server/TCPService/MessageHandler.hs
@@ -28,7 +28,7 @@ import qualified Data.Vector as V
 
 getBlockMetaSlice :: Currency -> BlockHeight -> BlockHeight -> ServerM [BlockMetaRec]
 getBlockMetaSlice currency startHeight amount = do
-  db <- getFiltersDb
+  db <- readFiltersDb
   let start = BlockMetaRecKey currency $ startHeight
       startBinary = metaRecKey (currency, startHeight)
       end = BlockMetaRecKey currency $ startHeight + amount


### PR DESCRIPTION
* Move DB context into MVars
* Old getters just read the value, but do not take it
* Empty the MVar only when "Bad magic number" error pops up and we want to be sure that no other thread tries using the db handler.
* When the MVar is taken wait 10 seconds before closing it just in case a thread is currently using the handler
* perform unsafeClose, open the db again and put the new handler into MVar

close #812 