### PR TITLE
Fix possible race for rollback TVar

### DIFF
--- a/index-server/src/Ergvein/Index/Server/App.hs
+++ b/index-server/src/Ergvein/Index/Server/App.hs
@@ -44,9 +44,9 @@ finalize env scannerThreads workerTreads = do
   rse <- fmap RollbackSequence $ liftIO $ readTVarIO (envBtcRollback env)
   runReaderT (storeRollbackSequence BTC rse) (envIndexerDBContext env)
   logInfoN "Waiting for scaner threads to close"
-  liftIO $ sequence_ $ wait <$> scannerThreads
+  liftIO $ mapM_ wait scannerThreads
   logInfoN "Waiting for other threads to close"
-  liftIO $ sequence_ $ wait <$> workerTreads
+  liftIO $ mapM_ wait workerTreads
   logInfoN "service is stopped"
 
 app :: (MonadUnliftIO m, MonadLogger m) => Bool -> Config -> ServerEnv -> m ()

--- a/index-server/src/Ergvein/Index/Server/DB/Queries.hs
+++ b/index-server/src/Ergvein/Index/Server/DB/Queries.hs
@@ -163,13 +163,8 @@ insertBtcRollback :: (HasBtcRollback m, HasFiltersDB m, MonadLogger m, MonadBase
   => RollbackRecItem -> m ()
 insertBtcRollback ritem = do
   rollVar <- getBtcRollbackVar
-  rse <- liftIO $ readTVarIO rollVar
-  let rse' = ritem Seq.<| rse
-  if Seq.length rse' <= btcRollbackSize
-    then liftIO $ atomically $ writeTVar rollVar rse'
-    else do
-      let rest Seq.:> _ = Seq.viewr rse'
-      liftIO $ atomically $ writeTVar rollVar rest
+  liftIO $ atomically $ modifyTVar' rollVar $ \rse ->
+    Seq.take btcRollbackSize $ ritem Seq.<| rse
 
 storeRollbackSequence :: (HasIndexerDB m, MonadLogger m) => Currency -> RollbackSequence -> m ()
 storeRollbackSequence cur rse = do


### PR DESCRIPTION
TVar should be modified in transaction if possible. Otherwise it's possible to get races during concurrent modification
