### PR TITLE
Correctly close database on program shutdown

### DIFF
--- a/index-server/app/Main.hs
+++ b/index-server/app/Main.hs
@@ -86,7 +86,7 @@ startServer Options{..} = case optsCommand of
       cfg@Config{..} <- loadConfig cfgPath
       BitcoinApi.withClient cfgBTCNodeHost cfgBTCNodePort cfgBTCNodeUser cfgBTCNodePassword $ \client -> do
         runStdoutLoggingT $ withNewServerEnv optsBtcTcpConn optsOverrideFilters optsOverrideIndexers optsOverrideUtxo client cfg $ \env -> do
-          app optsOnlyScan cfg env
+          app optsOnlyScan optsSkipBtcHack cfg env
     CleanKnownPeers cfgPath -> do
       cfg@Config{..} <- loadConfig cfgPath
       BitcoinApi.withClient cfgBTCNodeHost cfgBTCNodePort cfgBTCNodeUser cfgBTCNodePassword $ \client -> do

--- a/index-server/app/Main.hs
+++ b/index-server/app/Main.hs
@@ -96,6 +96,6 @@ startServer Options{..} = case optsCommand of
     BuildBtcIndex cfgPath n -> do
       cfg@Config{..} <- loadConfig cfgPath
       BitcoinApi.withClient cfgBTCNodeHost cfgBTCNodePort cfgBTCNodeUser cfgBTCNodePassword $ \client -> do
-        env <- runStdoutLoggingT $ newTxIndexEnv optsBtcTcpConn client cfg
-        runStdoutLoggingT $ txIndexApp optsBtcStartHeight n env
+        runStdoutLoggingT $ withTxIndexEnv optsBtcTcpConn client cfg $ \env -> do
+          txIndexApp optsBtcStartHeight n env
       T.putStrLn $ pack "Index builder done"

--- a/index-server/ergvein-index-server.cabal
+++ b/index-server/ergvein-index-server.cabal
@@ -30,6 +30,7 @@ library
     Ergvein.Index.Server.DB.Serialize
     Ergvein.Index.Server.DB.Serialize.Class
     Ergvein.Index.Server.DB.Utils
+    Ergvein.Index.Server.DB.Wrapper
     Ergvein.Index.Server.Dependencies
     Ergvein.Index.Server.Environment
     Ergvein.Index.Server.Metrics

--- a/index-server/src/Ergvein/Index/Server/BlockchainScanning/Bitcoin.hs
+++ b/index-server/src/Ergvein/Index/Server/BlockchainScanning/Bitcoin.hs
@@ -89,7 +89,7 @@ actualHeight = fromIntegral <$> nodeRpcCall getBlockCount
 getTxFromCache :: (HasFiltersDB m, MonadLogger m)
   => TxHash -> m (Either String HK.Tx)
 getTxFromCache thash = do
-  db <- readFiltersDb
+  db <- getFiltersDb
   msrc <- getParsed BTC "getTxFromCache" db $ txBytesKey thash
   pure $ case msrc of
     Nothing -> Left $ "Tx not found. TxHash: " <> show thash
@@ -98,7 +98,7 @@ getTxFromCache thash = do
 getTxFromNode :: (BitcoinApiMonad m, MonadLogger m, MonadBaseControl IO m, HasFiltersDB m)
   => HK.TxHash -> m HK.Tx
 getTxFromNode thash = do
-  db <- readFiltersDb
+  db <- getFiltersDb
   txHeight <- fmap unTxRecHeight $
     getParsedExact BTC "getTxFromNode" db $ txHeightKey $ hkTxHashToEgv thash
   blk <- getBtcBlock $ fromIntegral txHeight

--- a/index-server/src/Ergvein/Index/Server/BlockchainScanning/Bitcoin.hs
+++ b/index-server/src/Ergvein/Index/Server/BlockchainScanning/Bitcoin.hs
@@ -196,7 +196,7 @@ btcDbConsistencyCheck = do
         Just (BlockInfoRec hh _) -> if blockHeaderHash /= hh
           then pure False       -- Filter is for the wrong block (how??)
           else do
-            udb <- readUtxoDb
+            udb <- getUtxoDb
             checkTxs udb txIds  -- check that all transaction are stored
   where
     clearRollback = do

--- a/index-server/src/Ergvein/Index/Server/DB.hs
+++ b/index-server/src/Ergvein/Index/Server/DB.hs
@@ -14,7 +14,7 @@ import Database.LevelDB.Base
 import System.Directory
 
 import Ergvein.Index.Server.DB.Monad
-
+import Ergvein.Index.Server.DB.Wrapper
 import qualified Ergvein.Index.Server.DB.Schema.Filters as DBF
 import qualified Ergvein.Index.Server.DB.Schema.Indexer as DBI
 
@@ -23,18 +23,18 @@ data MyException = DbVersionMismatch
 
 instance Exception MyException
 
-openDb :: (MonadLogger m, MonadIO m) => Bool -> DBTag -> FilePath -> m DB
+openDb :: (MonadLogger m, MonadIO m) => Bool -> DBTag -> FilePath -> m LevelDB
 openDb overwriteDbVerOnMismatch dbtag dbDirectory = do
   canonicalPathDirectory <- liftIO $ canonicalizePath dbDirectory
   dbStatePresent <- liftIO $ doesDirectoryExist canonicalPathDirectory
   liftIO $ unless dbStatePresent $ createDirectory canonicalPathDirectory
   levelDBContext <- liftIO $ do
-    db <- open canonicalPathDirectory def {createIfMissing = True }
+    db <- openLevelDB canonicalPathDirectory def {createIfMissing = True }
     if overwriteDbVerOnMismatch || not dbStatePresent then do
-      put db def schemaVersionRecKey schemaVersion
+      putLDB db def schemaVersionRecKey schemaVersion
       pure db
     else do
-      dbSchemaVersion <- get db def schemaVersionRecKey
+      dbSchemaVersion <- getLDB db def schemaVersionRecKey
       if dbSchemaVersion == Just schemaVersion then
         pure db
       else do

--- a/index-server/src/Ergvein/Index/Server/DB/Monad.hs
+++ b/index-server/src/Ergvein/Index/Server/DB/Monad.hs
@@ -9,7 +9,6 @@ import Ergvein.Index.Server.DB.Schema.Indexer
 import Ergvein.Index.Server.DB.Wrapper
 
 import qualified Data.Sequence as Seq
-import qualified Database.LevelDB as LDB
 
 class  MonadIO m => HasFiltersDB m where
   getFiltersDb :: m LevelDB

--- a/index-server/src/Ergvein/Index/Server/DB/Monad.hs
+++ b/index-server/src/Ergvein/Index/Server/DB/Monad.hs
@@ -2,7 +2,6 @@
 module Ergvein.Index.Server.DB.Monad where
 
 import Control.Concurrent.STM
-import Control.Concurrent
 import Control.Monad.IO.Unlift
 import Control.Monad.Reader
 

--- a/index-server/src/Ergvein/Index/Server/DB/Monad.hs
+++ b/index-server/src/Ergvein/Index/Server/DB/Monad.hs
@@ -7,15 +7,16 @@ import Control.Monad.IO.Unlift
 import Control.Monad.Reader
 
 import Ergvein.Index.Server.DB.Schema.Indexer
+import Ergvein.Index.Server.DB.Wrapper
 
 import qualified Data.Sequence as Seq
 import qualified Database.LevelDB as LDB
 
 class  MonadIO m => HasFiltersDB m where
-  getFiltersDbVar :: m (MVar LDB.DB)
+  getFiltersDb :: m LevelDB
 
 class MonadIO m => HasIndexerDB m where
-  getIndexerDbVar :: m (MVar LDB.DB)
+  getIndexerDb :: m LevelDB
 
 class MonadIO m => HasLMDBs m where
   getDb :: DBTag -> m LDB.DB
@@ -26,14 +27,8 @@ data DBTag = DBFilters | DBIndexer
 class HasBtcRollback m where
   getBtcRollbackVar :: m (TVar (Seq.Seq RollbackRecItem))
 
-instance MonadIO m => HasIndexerDB (ReaderT (MVar LDB.DB) m) where
-  getIndexerDbVar = ask
+instance MonadIO m => HasIndexerDB (ReaderT LevelDB m) where
+  getIndexerDb = ask
 
-instance MonadIO m => HasFiltersDB (ReaderT (MVar LDB.DB) m) where
-  getFiltersDbVar  = ask
-
-readFiltersDb :: HasFiltersDB m => m LDB.DB
-readFiltersDb = liftIO . readMVar =<< getFiltersDbVar
-
-readIndexerDb :: HasIndexerDB m => m LDB.DB
-readIndexerDb = liftIO . readMVar =<< getIndexerDbVar
+instance MonadIO m => HasFiltersDB (ReaderT LevelDB m) where
+  getFiltersDb  = ask

--- a/index-server/src/Ergvein/Index/Server/DB/Monad.hs
+++ b/index-server/src/Ergvein/Index/Server/DB/Monad.hs
@@ -18,10 +18,10 @@ class MonadIO m => HasIndexerDB m where
   getIndexerDb :: m LevelDB
 
 class MonadIO m => HasUtxoDB m where
-  getUtxoDbVar :: m (MVar LDB.DB)
+  getUtxoDb :: m LevelDB
 
 class MonadIO m => HasLMDBs m where
-  getDb :: DBTag -> m LDB.DB
+  getDb :: DBTag -> m LevelDB
 
 data DBTag = DBFilters | DBIndexer | DBUtxo
   deriving (Eq, Show)
@@ -35,24 +35,20 @@ instance MonadIO m => HasIndexerDB (ReaderT LevelDB m) where
 instance MonadIO m => HasFiltersDB (ReaderT LevelDB m) where
   getFiltersDb  = ask
 
-instance MonadIO m => HasUtxoDB (ReaderT (MVar LDB.DB) m) where
-  getUtxoDbVar  = ask
+instance MonadIO m => HasUtxoDB (ReaderT LevelDB m) where
+  getUtxoDb = ask
 
 data AllDbVars = AllDbVars {
-  allDBFilters :: MVar LDB.DB
-, allDBIndexer :: MVar LDB.DB
-, allDBUtxo    :: MVar LDB.DB
+  allDBFilters :: LevelDB
+, allDBIndexer :: LevelDB
+, allDBUtxo    :: LevelDB
 }
 
 instance MonadIO m => HasIndexerDB (ReaderT AllDbVars m) where
-  getIndexerDbVar = asks allDBFilters
+  getIndexerDb = asks allDBFilters
 
 instance MonadIO m => HasFiltersDB (ReaderT AllDbVars m) where
-  getFiltersDbVar  = asks allDBIndexer
+  getFiltersDb  = asks allDBIndexer
 
 instance MonadIO m => HasUtxoDB (ReaderT AllDbVars m) where
-  getUtxoDbVar  = asks allDBUtxo
-
-
-readUtxoDb :: HasUtxoDB m => m LDB.DB
-readUtxoDb = liftIO . readMVar =<< getUtxoDbVar
+  getUtxoDb  = asks allDBUtxo

--- a/index-server/src/Ergvein/Index/Server/DB/Utils.hs
+++ b/index-server/src/Ergvein/Index/Server/DB/Utils.hs
@@ -23,8 +23,6 @@ import Data.Either
 import Data.Serialize (Serialize)
 import Data.Text
 import Data.Time
-import Database.LevelDB
-import Database.LevelDB.Iterator
 
 import Ergvein.Index.Server.DB.Serialize.Class
 import Ergvein.Index.Server.DB.Wrapper

--- a/index-server/src/Ergvein/Index/Server/DB/Utils.hs
+++ b/index-server/src/Ergvein/Index/Server/DB/Utils.hs
@@ -54,12 +54,8 @@ parsedKey = fromRight (error "ser") . S.decode . unPrefixedKey
 
 safeEntrySlice :: (EgvSerialize v, MonadIO m , Ord k, S.Serialize k) => Currency -> LevelDB -> BS.ByteString -> k -> k -> m [(k,v)]
 safeEntrySlice cur db startKeyBinary startKey endKey = do
-  -- FIXME: Decide what to do with iterator
-  --
-  -- iterator <- createIter db def
-  -- slice <- LDBStreaming.toList $ LDBStreaming.entrySlice iterator range LDBStreaming.Asc
-  -- pure $ over _2 (unflatExact cur "safeEntrySlice")  <$> over _1 (decodeExact . unPrefixedKey) <$> slice
-  undefined
+  slice <- streamSliceLDB db range LDBStreaming.Asc
+  pure $ over _2 (unflatExact cur "safeEntrySlice")  <$> over _1 (decodeExact . unPrefixedKey) <$> slice
   where    
     range = LDBStreaming.KeyRange startKeyBinary comparison
     comparison key = case S.decode $ unPrefixedKey key of

--- a/index-server/src/Ergvein/Index/Server/DB/Utils.hs
+++ b/index-server/src/Ergvein/Index/Server/DB/Utils.hs
@@ -27,6 +27,7 @@ import Database.LevelDB
 import Database.LevelDB.Iterator
 
 import Ergvein.Index.Server.DB.Serialize.Class
+import Ergvein.Index.Server.DB.Wrapper
 import Ergvein.Types.Currency
 
 import qualified Data.ByteString as BS
@@ -51,27 +52,30 @@ unPrefixedKey = BS.tail
 parsedKey :: Serialize k => ByteString -> k
 parsedKey = fromRight (error "ser") . S.decode . unPrefixedKey
 
-safeEntrySlice :: (EgvSerialize v, MonadIO m , Ord k, S.Serialize k) => Currency -> DB -> BS.ByteString -> k -> k -> m [(k,v)]
+safeEntrySlice :: (EgvSerialize v, MonadIO m , Ord k, S.Serialize k) => Currency -> LevelDB -> BS.ByteString -> k -> k -> m [(k,v)]
 safeEntrySlice cur db startKeyBinary startKey endKey = do
-  iterator <- createIter db def
-  slice <- LDBStreaming.toList $ LDBStreaming.entrySlice iterator range LDBStreaming.Asc
-  pure $ over _2 (unflatExact cur "safeEntrySlice")  <$> over _1 (decodeExact . unPrefixedKey) <$> slice
-  where
+  -- FIXME: Decide what to do with iterator
+  --
+  -- iterator <- createIter db def
+  -- slice <- LDBStreaming.toList $ LDBStreaming.entrySlice iterator range LDBStreaming.Asc
+  -- pure $ over _2 (unflatExact cur "safeEntrySlice")  <$> over _1 (decodeExact . unPrefixedKey) <$> slice
+  undefined
+  where    
     range = LDBStreaming.KeyRange startKeyBinary comparison
     comparison key = case S.decode $ unPrefixedKey key of
       Right parsedK -> if startKey <= parsedK && parsedK <= endKey then LT else GT
       _ -> GT
 
-getParsed :: (EgvSerialize v, MonadIO m) => Currency -> Text -> DB -> BS.ByteString -> m (Maybe v)
+getParsed :: (EgvSerialize v, MonadIO m) => Currency -> Text -> LevelDB -> BS.ByteString -> m (Maybe v)
 getParsed cur c db key = do
-  maybeResult <- get db def key
+  maybeResult <- getLDB db def key
   let caller = "getParsed: " <> c
   let maybeParsedResult = (unflatExact cur caller) <$> maybeResult
   pure maybeParsedResult
 
-getParsedExact :: (EgvSerialize v, MonadIO m, MonadLogger m) => Currency -> Text -> DB -> BS.ByteString -> m v
+getParsedExact :: (EgvSerialize v, MonadIO m, MonadLogger m) => Currency -> Text -> LevelDB -> BS.ByteString -> m v
 getParsedExact cur caller db key = do
-  maybeResult <- get db def key
+  maybeResult <- getLDB db def key
   case maybeResult of
     Just result -> pure $ unflatExact cur caller result
     Nothing -> do
@@ -79,7 +83,7 @@ getParsedExact cur caller db key = do
       logErrorN $ "[Db read miss][getParsedExact]" <> "["<> caller <>"]"<> " Entity with key " <> (T.pack $ show key) <> " not found at time:" <> (T.pack $ show currentTime)
       error $ "getParsedExact: not found" ++ show key
 
-getManyParsedExact :: (EgvSerialize v, MonadIO m, MonadLogger m) => Currency -> Text -> DB -> [BS.ByteString] -> m [v]
+getManyParsedExact :: (EgvSerialize v, MonadIO m, MonadLogger m) => Currency -> Text -> LevelDB -> [BS.ByteString] -> m [v]
 getManyParsedExact cur caller db keys = traverse (getParsedExact cur caller db) keys
 
 putItems :: (EgvSerialize v) => Currency -> (a -> BS.ByteString) -> (a -> v) -> [a] -> LDB.WriteBatch
@@ -89,6 +93,6 @@ putItems cur keySelector valueSelector items = putI <$> items
 putItem :: (EgvSerialize v) => Currency -> BS.ByteString -> v -> LDB.WriteBatch
 putItem cur key item = [LDB.Put key $ egvSerialize cur item]
 
-upsertItem :: (EgvSerialize v, MonadIO m, MonadLogger m) => Currency -> DB -> BS.ByteString -> v -> m ()
+upsertItem :: (EgvSerialize v, MonadIO m, MonadLogger m) => Currency -> LevelDB -> BS.ByteString -> v -> m ()
 upsertItem cur db key item = do
-  put db def key $ egvSerialize cur item
+  putLDB db def key $ egvSerialize cur item

--- a/index-server/src/Ergvein/Index/Server/DB/Wrapper.hs
+++ b/index-server/src/Ergvein/Index/Server/DB/Wrapper.hs
@@ -17,7 +17,7 @@ module Ergvein.Index.Server.DB.Wrapper
   , streamSliceLDB
   ) where
 
-import Control.Concurrent.MVar
+import Control.Concurrent.STM
 import Control.Exception
 import Control.Monad.IO.Class
 import Data.Default
@@ -30,35 +30,52 @@ import qualified Database.LevelDB.Streaming as Stream
 -- | Connection to database. Actual connection is stored inside @MVar@
 -- and @Nothing@ is stored on when connection is closed. This way user
 -- won't be able to use now invalid connection,
-newtype LevelDB = LevelDB (MVar (Maybe DB))
+data LevelDB = LevelDB
+  { dbHandle :: TVar (Maybe DB) -- ^ Database handle.
+  , dbActive :: TVar Int        -- ^ Number of active DB operations
+  }
 
 -- | Open handle to a database
 openLevelDB :: MonadIO m => FilePath -> Options -> m LevelDB
 openLevelDB path opt = liftIO $ do
-  mv <- newEmptyMVar
-  db <- open path opt
-  putMVar mv (Just db)
-  pure $ LevelDB mv
+  dbActive <- newTVarIO 0
+  dbHandle <- newTVarIO . Just =<< open path opt
+  pure LevelDB{..}
 
 -- | Close and then immediately reopen database
 moveLevelDbHandle :: MonadIO m => LevelDB -> LevelDB -> m ()
-moveLevelDbHandle (LevelDB src) (LevelDB dst) = liftIO $ modifyMVar src $ \case
-  Nothing -> error "moveLevelDbHandle: can't move from closed handle"
-  Just h  -> modifyMVar dst $ \mh -> do
-    mapM_ unsafeClose mh
-    pure (Just h, (Nothing, ()))
+moveLevelDbHandle src dst = liftIO $ do
+  -- First close destination database
+  closeLevelDB dst
+  -- Move new one.
+  atomically $ do
+    writeTVar (dbHandle dst) =<< readTVar (dbHandle src)
+    writeTVar (dbActive dst) =<< readTVar (dbActive src)
+    writeTVar (dbHandle src) Nothing
+    writeTVar (dbActive src) 0
 
 -- | Close handle. After close it's no longer usable and any database
 -- operation which uses this handle will throw exception.
 closeLevelDB :: MonadIO m => LevelDB -> m ()
-closeLevelDB (LevelDB mv) = liftIO $ do
-  modifyMVar mv $ \mconn ->
-    (Nothing, ()) <$ mapM_ unsafeClose mconn
+-- FIXME: Masking???
+closeLevelDB LevelDB{..} = liftIO $ do
+  -- First mark database as closed so no new transaction could be started
+  mdb <- atomically $ readTVar dbHandle <* writeTVar dbHandle Nothing
+  case mdb of
+    Nothing -> pure ()
+    Just db -> do
+      -- Wait until all requests are finished then close database
+      atomically $ check . (==0) =<< readTVar dbActive
+      unsafeClose db
+
 
 usingLevelDB :: MonadIO m => LevelDB -> (DB -> IO a) -> m a
-usingLevelDB (LevelDB h) action = liftIO $ withMVar h $ \case
-  Nothing -> error "usingLevelDB: database is already closed"
-  Just c  -> action c
+usingLevelDB LevelDB{..} = liftIO . bracket ini fini
+  where
+    ini = atomically $ readTVar dbHandle >>= \case
+      Nothing -> error "LevelDB: Database is closed"
+      Just db -> db <$ modifyTVar' dbActive succ
+    fini _ = atomically $ modifyTVar' dbActive pred
 
 
 ----------------------------------------------------------------

--- a/index-server/src/Ergvein/Index/Server/DB/Wrapper.hs
+++ b/index-server/src/Ergvein/Index/Server/DB/Wrapper.hs
@@ -9,11 +9,15 @@ module Ergvein.Index.Server.DB.Wrapper
   ( LevelDB
   , openLevelDB
   , closeLevelDB
+    -- * Wrapped operations
   , writeLDB
+  , getLDB
+  , putLDB
   ) where
 
 import Control.Concurrent.MVar
 import Control.Monad.IO.Class
+import Data.ByteString           (ByteString)
 import Database.LevelDB.Base
 import Database.LevelDB.Internal (unsafeClose)
 
@@ -42,6 +46,16 @@ usingLevelDB (LevelDB h) action = liftIO $ withMVar h $ \case
   Nothing -> error "usingLevelDB: database is already closed"
   Just c  -> action c
 
--- | Wrapped 'write'
+
+----------------------------------------------------------------
+-- Wrappers
+----------------------------------------------------------------
+
 writeLDB :: MonadIO m => LevelDB -> WriteOptions -> WriteBatch -> m ()
 writeLDB db opt batch = usingLevelDB db $ \c -> write c opt batch
+
+getLDB :: MonadIO m => LevelDB -> ReadOptions -> ByteString -> m (Maybe ByteString)
+getLDB db opt key = usingLevelDB db $ \c -> get c opt key
+
+putLDB :: MonadIO m => LevelDB -> WriteOptions -> ByteString -> ByteString -> m ()
+putLDB db opt k v = usingLevelDB db $ \c -> put c opt k v

--- a/index-server/src/Ergvein/Index/Server/DB/Wrapper.hs
+++ b/index-server/src/Ergvein/Index/Server/DB/Wrapper.hs
@@ -1,0 +1,47 @@
+-- |
+-- This module provides wrapper for LevelDB's connection which allows
+-- safe closing in concurrent setting. Any use of connection after
+-- 'unsafeClose' will lead memory corruption. (It's called unsafe for
+-- reason). When connection is shared by several threads it's
+-- 'withConnection' is not safe either. Thread may be killed _after_
+-- connection is closed.
+module Ergvein.Index.Server.DB.Wrapper
+  ( LevelDB
+  , openLevelDB
+  , closeLevelDB
+  , writeLDB
+  ) where
+
+import Control.Concurrent.MVar
+import Control.Monad.IO.Class
+import Database.LevelDB.Base
+import Database.LevelDB.Internal (unsafeClose)
+
+-- | Connection to database. Actual connection is stored inside @MVar@
+-- and @Nothing@ is stored on when connection is closed. This way user
+-- won't be able to use now invalid connection,
+newtype LevelDB = LevelDB (MVar (Maybe DB))
+
+-- | Open handle to a database
+openLevelDB :: MonadIO m => FilePath -> Options -> m LevelDB
+openLevelDB path opt = liftIO $ do
+  mv <- newEmptyMVar
+  db <- open path opt
+  putMVar mv (Just db)
+  pure $ LevelDB mv
+
+-- | Close handle. After close it's no longer usable and any database
+-- operation which uses this handle will throw exception.
+closeLevelDB :: MonadIO m => LevelDB -> m ()
+closeLevelDB (LevelDB mv) = liftIO $ do
+  modifyMVar mv $ \mconn ->
+    (Nothing, ()) <$ mapM_ unsafeClose mconn
+
+usingLevelDB :: MonadIO m => LevelDB -> (DB -> IO a) -> m a
+usingLevelDB (LevelDB h) action = liftIO $ withMVar h $ \case
+  Nothing -> error "usingLevelDB: database is already closed"
+  Just c  -> action c
+
+-- | Wrapped 'write'
+writeLDB :: MonadIO m => LevelDB -> WriteOptions -> WriteBatch -> m ()
+writeLDB db opt batch = usingLevelDB db $ \c -> write c opt batch

--- a/index-server/src/Ergvein/Index/Server/DB/Wrapper.hs
+++ b/index-server/src/Ergvein/Index/Server/DB/Wrapper.hs
@@ -22,7 +22,6 @@ import Control.Exception
 import Control.Monad.IO.Class
 import Data.Default
 import Data.ByteString           (ByteString)
-import qualified Data.Serialize as S
 import Database.LevelDB.Base
 import Database.LevelDB.Internal (unsafeClose)
 import Database.LevelDB.Streaming (entrySlice,Entry,KeyRange,Direction)

--- a/index-server/src/Ergvein/Index/Server/Environment.hs
+++ b/index-server/src/Ergvein/Index/Server/Environment.hs
@@ -176,22 +176,15 @@ logOnException threadName = handle logE
             then do
               logInfoN' "Halted by \"not an sstable (bad magic nuber)\" error. Repairing the db."
               Config{..} <- serverConfig
-              -- FIXME: Implement opening and closing of database
-              --
-              -- fdbVar <- getFiltersDbVar
-              -- idbVar <- getIndexerDbVar
-              -- fdb <- liftIO $ takeMVar fdbVar
-              -- idb <- liftIO $ takeMVar idbVar
-              -- logInfoN' "Waiting 10s before closing, just in case"
-              -- liftIO $ threadDelay 10000000
-              -- liftIO $ unsafeClose fdb
-              -- liftIO $ unsafeClose idb
-              -- filtersDBCntx  <- openDb False DBFilters cfgFiltersDbPath
-              -- indexerDBCntx  <- openDb False DBIndexer cfgIndexerDbPath
-              -- liftIO $ putMVar fdbVar filtersDBCntx
-              -- liftIO $ putMVar idbVar indexerDBCntx
-              -- logInfoN' "Reopened the db. Resume as usual"
-              undefined
+              fdb <- getFiltersDb
+              idb <- getIndexerDb
+              closeLevelDB fdb
+              closeLevelDB idb
+              fdb' <- openDb False DBFilters cfgFiltersDbPath
+              idb' <- openDb False DBIndexer cfgIndexerDbPath
+              moveLevelDbHandle fdb' fdb
+              moveLevelDbHandle idb' idb
+              logInfoN' "Reopened the db. Resume as usual"
             else
               logErrorN' $ "Killed by IOException. " <> showt ioe
           liftIO $ threadDelay 1000000

--- a/index-server/src/Ergvein/Index/Server/Environment.hs
+++ b/index-server/src/Ergvein/Index/Server/Environment.hs
@@ -11,8 +11,6 @@ import Control.Monad.Logger
 import Control.Monad.Reader
 import Data.Text (Text, isInfixOf)
 import Data.Typeable
-import Database.LevelDB.Base
-import Database.LevelDB.Internal (unsafeClose)
 import Network.HTTP.Client.TLS
 import Network.Socket
 import System.IO

--- a/index-server/src/Ergvein/Index/Server/Monad.hs
+++ b/index-server/src/Ergvein/Index/Server/Monad.hs
@@ -38,12 +38,12 @@ runServerMIO :: ServerEnv -> ServerM a -> IO a
 runServerMIO e = runChanLoggingT (envLogger e) . flip runReaderT e . unServerM
 
 instance HasFiltersDB ServerM where
-  getFiltersDbVar = asks envFiltersDBContext
-  {-# INLINE getFiltersDbVar #-}
+  getFiltersDb = asks envFiltersDBContext
+  {-# INLINE getFiltersDb #-}
 
 instance HasIndexerDB ServerM where
-  getIndexerDbVar = asks envIndexerDBContext
-  {-# INLINE getIndexerDbVar #-}
+  getIndexerDb = asks envIndexerDBContext
+  {-# INLINE getIndexerDb #-}
 
 instance HasBtcRollback ServerM where
   getBtcRollbackVar = asks envBtcRollback

--- a/index-server/src/Ergvein/Index/Server/Monad.hs
+++ b/index-server/src/Ergvein/Index/Server/Monad.hs
@@ -46,8 +46,8 @@ instance HasIndexerDB ServerM where
   {-# INLINE getIndexerDb #-}
 
 instance HasUtxoDB ServerM where
-  getUtxoDbVar = asks envUtxoDBContext
-  {-# INLINE getUtxoDbVar #-}
+  getUtxoDb = asks envUtxoDBContext
+  {-# INLINE getUtxoDb #-}
 
 instance HasBtcRollback ServerM where
   getBtcRollbackVar = asks envBtcRollback

--- a/index-server/src/Ergvein/Index/Server/TCPService/MessageHandler.hs
+++ b/index-server/src/Ergvein/Index/Server/TCPService/MessageHandler.hs
@@ -28,7 +28,7 @@ import qualified Data.Vector as V
 
 getBlockMetaSlice :: Currency -> BlockHeight -> BlockHeight -> ServerM [BlockMetaRec]
 getBlockMetaSlice currency startHeight amount = do
-  db <- readFiltersDb
+  db <- getFiltersDb
   let start = BlockMetaRecKey currency $ startHeight
       startBinary = metaRecKey (currency, startHeight)
       end = BlockMetaRecKey currency $ startHeight + amount

--- a/index-server/src/Ergvein/Index/Server/TxIndex.hs
+++ b/index-server/src/Ergvein/Index/Server/TxIndex.hs
@@ -1,7 +1,7 @@
 module Ergvein.Index.Server.TxIndex
   (
     txIndexApp
-  , newTxIndexEnv
+  , withTxIndexEnv
   ) where
 
 import Control.Concurrent.Async.Lifted


### PR DESCRIPTION
We have following problems: 1) we have to close database on program shutdown instead of relying of so-so crash resilience of leveldb 2) doing it properly is not trivial. `unsafeClose` _is_ unsafe and any use of connection after close will corrupt memory. In concurrent setting it's even worse. Thread may get killed _after_ connection is closed and will use now invalid connection.

Approach in this PR is simplest one. handle is stored inside a MVar and every DB operations takes connection from MVar and puts it back at the end in effect serializing access. It's probably possible to use semaphores in order to regain some parallelism

Also fixes problem with leak of iterators. They were never closed

P.S. Not actually tested