### PR TITLE
Indexer hacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,4 @@ ergvein.aux
 ergvein.ps
 *.prof
 TAGS
-index-server/ergveinDb/*
-index-server/indexerDb/*
+index-server/db_*/*

--- a/index-server/buildTxIndex.mainnet.sh
+++ b/index-server/buildTxIndex.mainnet.sh
@@ -1,0 +1,1 @@
+cabal new-run exe:ergvein-index-server -- --no-btc-hack --tcp-node $1 build-index -n4 ./configuration.mainnet.yaml

--- a/index-server/configuration.mainnet.yaml
+++ b/index-server/configuration.mainnet.yaml
@@ -1,7 +1,8 @@
 serverPort               : 8085
 serverTcpPort            : 8667
-filtersDbPath            : "./ergveinDb_mainnet"
-indexerDbPath            : "./indexerDb_mainnet"
+filtersDbPath            : "./db_mainnet_filters"
+indexerDbPath            : "./db_mainnet_indexer"
+utxoDbPath               : "./db_mainnet_utxo"
 BTCNodeIsTestnet         : false
 BTCNodeHost              : localhost
 BTCNodePort              : 8332

--- a/index-server/configuration.testnet.yaml
+++ b/index-server/configuration.testnet.yaml
@@ -1,7 +1,8 @@
 serverPort               : 8085
 serverTcpPort            : 8667
-filtersDbPath            : "./ergveinDb_testnet"
-indexerDbPath            : "./indexerDb_testnet"
+filtersDbPath            : "./db_testnet_filters"
+indexerDbPath            : "./db_testnet_indexer"
+utxoDbPath               : "./db_testnet_utxo"
 BTCNodeIsTestnet         : true
 BTCNodeHost              : localhost
 BTCNodePort              : 18332

--- a/index-server/ergvein-index-server.cabal
+++ b/index-server/ergvein-index-server.cabal
@@ -27,6 +27,7 @@ library
     Ergvein.Index.Server.DB.Queries
     Ergvein.Index.Server.DB.Schema.Filters
     Ergvein.Index.Server.DB.Schema.Indexer
+    Ergvein.Index.Server.DB.Schema.Utxo
     Ergvein.Index.Server.DB.Serialize
     Ergvein.Index.Server.DB.Serialize.Class
     Ergvein.Index.Server.DB.Utils

--- a/index-server/ergvein-index-server.cabal
+++ b/index-server/ergvein-index-server.cabal
@@ -43,6 +43,8 @@ library
     Ergvein.Index.Server.TCPService.MessageHandler
     Ergvein.Index.Server.TCPService.Server
     Ergvein.Index.Server.TCPService.Socket
+    Ergvein.Index.Server.TxIndex
+    Ergvein.Index.Server.TxIndex.Monad
     Ergvein.Index.Server.Utils
     Ergvein.Index.Server.Worker.Fees
     Ergvein.Index.Server.Worker.Rates

--- a/index-server/src/Ergvein/Index/Server/App.hs
+++ b/index-server/src/Ergvein/Index/Server/App.hs
@@ -74,8 +74,6 @@ dirtyBtcHack = do
 cleanerBtcHack :: ServerM ()
 cleanerBtcHack = do
   isConsistent <- btcDbConsistencyCheck
-  logInfoN $ "Consistency: " <> showt isConsistent
-  liftIO $ getChar
   unless isConsistent $ do
     -- we set Nothing value to 1 to avoid checking for 0 later
     h <- fmap (fromMaybe 1) $ getScannedHeight BTC

--- a/index-server/src/Ergvein/Index/Server/App.hs
+++ b/index-server/src/Ergvein/Index/Server/App.hs
@@ -2,15 +2,17 @@ module Ergvein.Index.Server.App where
 
 import Control.Concurrent.STM
 import Control.Immortal
-import System.Posix.Signals
 import Control.Monad.IO.Unlift
 import Control.Monad.Logger
 import Control.Monad.Reader
+import Data.Maybe
+import Data.Sequence (Seq(..))
+import System.Posix.Signals
 
 import Ergvein.Index.Server.BlockchainScanning.Common
 import Ergvein.Index.Server.Config
-import Ergvein.Index.Server.DB.Queries (storeRollbackSequence)
-import Ergvein.Index.Server.DB.Schema.Indexer (RollbackSequence(..))
+import Ergvein.Index.Server.DB.Queries
+import Ergvein.Index.Server.DB.Schema.Indexer (RollbackSequence(..), RollbackRecItem(..))
 import Ergvein.Index.Server.Environment
 import Ergvein.Index.Server.Metrics
 import Ergvein.Index.Server.Monad
@@ -23,8 +25,48 @@ import Ergvein.Types.Currency
 
 import qualified Data.Text.IO as T
 
-onStartup :: Bool -> ServerEnv -> ServerM ([Thread], [Thread])
-onStartup onlyScan _ = do
+
+-- If something bad happens, like OOM, or sigKILL and the write is interrupted
+-- we might have an inconsistent database
+-- The bad thing affects only the last scanned block:
+-- either it's height was written but not the Txs
+-- or its hash was written but not its height
+-- So we always start from the block before the last one
+--
+-- If we have no rollback info -- just decrease the height by 1
+-- If we have rollback (meaning the server was shut down properly at some point)
+-- then check if it's consistent with the chain so far and then use it to keep track of the rollbacks
+-- if it's not consistent -- delete the sequence and just decrease the height
+--
+-- The worst case scenario: indexer double scans some blocks which is not an issue
+-- or it misses a fork (a rare event itself) in a very specific conditions:
+-- a) a fork happend
+-- b) indexer ended up on a soon to be deprecated branch
+-- c) while on the branch, indexer went offline
+-- b) indexer came back online only after the fork collapsed and consensus was reached
+-- If all of the above happen, you will have to resync the indexer
+-- It's better to resync the indexer anytime a fork happens (once on several years) anyway
+dirtyBtcHack :: ServerM ()
+dirtyBtcHack = do
+  h <- fmap (fromMaybe 0) $ getScannedHeight BTC
+  let noRoll = do
+        setScannedHeight BTC (h - 1)
+        deleteLastScannedBlock BTC
+        storeRollbackSequence BTC $ RollbackSequence mempty
+
+  when (h > 0) $ void $ do
+    rse <- liftIO . readTVarIO =<< asks envBtcRollback
+    case rse of
+      Empty -> noRoll
+      tip :<| rest -> if rollbackPrevHeight tip /= h - 1
+        then noRoll else do
+          setLastScannedBlock BTC $ rollbackPrevBlockHash tip
+          setScannedHeight BTC $ rollbackPrevHeight tip
+          storeRollbackSequence BTC $ RollbackSequence rest
+
+onStartup :: Bool -> Bool -> ServerEnv -> ServerM ([Thread], [Thread])
+onStartup onlyScan skipBtcHack _ = do
+  unless skipBtcHack dirtyBtcHack
   scanningWorkers <- blockchainScanning
   if onlyScan then pure (scanningWorkers, []) else do
     --syncWithDefaultPeers
@@ -52,11 +94,12 @@ finalize env scannerThreads workerTreads = do
   liftIO $ mapM_ wait workerTreads
   logInfoN "service is stopped"
 
-app :: (MonadUnliftIO m, MonadLogger m) => Bool -> Config -> ServerEnv -> m ()
-app onlyScan cfg env = do
-  (scannerThreads, workerThreads) <- liftIO $ runServerMIO env $ onStartup onlyScan env
+app :: (MonadUnliftIO m, MonadLogger m) => Bool -> Bool -> Config -> ServerEnv -> m ()
+app onlyScan skipBtcHack cfg env = do
+  (scannerThreads, workerThreads) <- liftIO $ runServerMIO env $ onStartup onlyScan skipBtcHack env
   runReaderT serveMetrics cfg
   logInfoN $ "Server started at:" <> (showt . cfgServerPort $ cfg)
   _ <- liftIO $ installHandler sigTERM (Catch $ onShutdown env) Nothing
+  _ <- liftIO $ installHandler sigINT  (Catch $ onShutdown env) Nothing
   liftIO $ cancelableDelay (envShutdownFlag env) (-1)
   finalize env scannerThreads workerThreads

--- a/index-server/src/Ergvein/Index/Server/BlockchainScanning/Types.hs
+++ b/index-server/src/Ergvein/Index/Server/BlockchainScanning/Types.hs
@@ -37,3 +37,10 @@ data ScanProgressInfo = ScanProgressInfo
   , nfoScannedHeight :: !BlockHeight
   , nfoActualHeight  :: !BlockHeight
   }
+
+data TxIndexInfo = TxIndexInfo
+  { txIndexInfoHeight :: !BlockHeight
+  , txIndexInfoBlockHash  :: !ShortByteString
+  , txIndexInfoPrevBlockHash :: !ShortByteString
+  , txIndexInfoIds :: ![TxHash]
+  }

--- a/index-server/src/Ergvein/Index/Server/Config.hs
+++ b/index-server/src/Ergvein/Index/Server/Config.hs
@@ -36,6 +36,7 @@ data Config = Config
   , cfgServerHostname           :: !String
   , cfgFiltersDbPath            :: !String
   , cfgIndexerDbPath            :: !String
+  , cfgUtxoDbPath               :: !String
   , cfgBlockchainScanDelay      :: !Int
   , cfgBTCNodeIsTestnet         :: !Bool
   , cfgBTCNodeHost              :: !String
@@ -72,6 +73,7 @@ instance FromJSON Config where
     cfgServerHostname           <- o .:? "serverHostname"   .!= "0.0.0.0"
     cfgFiltersDbPath            <- o .:? "filtersDbPath"    .!= "./ergveinDb"
     cfgIndexerDbPath            <- o .:? "indexerDbPath"    .!= "./indexerDb"
+    cfgUtxoDbPath               <- o .:? "utxoDbPath"       .!= "./utxoDb"
     cfgBTCNodeIsTestnet         <- o .:? "BTCNodeIsTestnet" .!= False
     cfgBTCNodeHost              <- o .:? "BTCNodeHost"      .!= "localhost"
     cfgBTCNodePort              <- o .:  "BTCNodePort"

--- a/index-server/src/Ergvein/Index/Server/DB.hs
+++ b/index-server/src/Ergvein/Index/Server/DB.hs
@@ -17,6 +17,7 @@ import Ergvein.Index.Server.DB.Monad
 
 import qualified Ergvein.Index.Server.DB.Schema.Filters as DBF
 import qualified Ergvein.Index.Server.DB.Schema.Indexer as DBI
+import qualified Ergvein.Index.Server.DB.Schema.Utxo    as DBU
 
 data MyException = DbVersionMismatch
     deriving Show
@@ -41,6 +42,7 @@ openDb overwriteDbVerOnMismatch dbtag dbDirectory = do
         let (dbName, overrideFlag) = case dbtag of
               DBFilters -> ("Filters", "--override-ver-filters")
               DBIndexer -> ("Indexer", "--override-ver-indexer")
+              DBUtxo    -> ("UTXO", "--override-ver-utxo")
         putStrLn $ "[" <> dbName <> "]: Error! Database version mismatch!"
         putStrLn $ "[" <> dbName <> "]: If you are sure, that the new schema is compatible, run with " <> overrideFlag
         throw DbVersionMismatch
@@ -49,3 +51,4 @@ openDb overwriteDbVerOnMismatch dbtag dbDirectory = do
     (schemaVersionRecKey, schemaVersion) = case dbtag of
       DBFilters -> (DBF.schemaVersionRecKey, DBF.schemaVersion)
       DBIndexer -> (DBI.schemaVersionRecKey, DBI.schemaVersion)
+      DBUtxo    -> (DBU.schemaVersionRecKey, DBU.schemaVersion)

--- a/index-server/src/Ergvein/Index/Server/DB/Monad.hs
+++ b/index-server/src/Ergvein/Index/Server/DB/Monad.hs
@@ -17,10 +17,13 @@ class  MonadIO m => HasFiltersDB m where
 class MonadIO m => HasIndexerDB m where
   getIndexerDbVar :: m (MVar LDB.DB)
 
+class MonadIO m => HasUtxoDB m where
+  getUtxoDbVar :: m (MVar LDB.DB)
+
 class MonadIO m => HasLMDBs m where
   getDb :: DBTag -> m LDB.DB
 
-data DBTag = DBFilters | DBIndexer
+data DBTag = DBFilters | DBIndexer | DBUtxo
   deriving (Eq, Show)
 
 class HasBtcRollback m where
@@ -32,8 +35,29 @@ instance MonadIO m => HasIndexerDB (ReaderT (MVar LDB.DB) m) where
 instance MonadIO m => HasFiltersDB (ReaderT (MVar LDB.DB) m) where
   getFiltersDbVar  = ask
 
+instance MonadIO m => HasUtxoDB (ReaderT (MVar LDB.DB) m) where
+  getUtxoDbVar  = ask
+
+data AllDbVars = AllDbVars {
+  allDBFilters :: MVar LDB.DB
+, allDBIndexer :: MVar LDB.DB
+, allDBUtxo    :: MVar LDB.DB
+}
+
+instance MonadIO m => HasIndexerDB (ReaderT AllDbVars m) where
+  getIndexerDbVar = asks allDBFilters
+
+instance MonadIO m => HasFiltersDB (ReaderT AllDbVars m) where
+  getFiltersDbVar  = asks allDBIndexer
+
+instance MonadIO m => HasUtxoDB (ReaderT AllDbVars m) where
+  getUtxoDbVar  = asks allDBUtxo
+
 readFiltersDb :: HasFiltersDB m => m LDB.DB
 readFiltersDb = liftIO . readMVar =<< getFiltersDbVar
 
 readIndexerDb :: HasIndexerDB m => m LDB.DB
 readIndexerDb = liftIO . readMVar =<< getIndexerDbVar
+
+readUtxoDb :: HasUtxoDB m => m LDB.DB
+readUtxoDb = liftIO . readMVar =<< getUtxoDbVar

--- a/index-server/src/Ergvein/Index/Server/DB/Queries.hs
+++ b/index-server/src/Ergvein/Index/Server/DB/Queries.hs
@@ -10,6 +10,7 @@ module Ergvein.Index.Server.DB.Queries
   , initIndexerDb
   , setLastScannedBlock
   , getLastScannedBlock
+  , deleteLastScannedBlock
   -- * Filters db queries
   , getScannedHeight
   , setScannedHeight
@@ -41,6 +42,7 @@ import Ergvein.Index.Server.BlockchainScanning.Types
 import Ergvein.Index.Server.DB.Monad
 import Ergvein.Index.Server.DB.Schema.Filters
 import Ergvein.Index.Server.DB.Schema.Indexer
+import Ergvein.Index.Server.DB.Schema.Utxo
 import Ergvein.Index.Server.DB.Serialize
 import Ergvein.Index.Server.DB.Utils
 import Ergvein.Index.Server.Dependencies
@@ -105,22 +107,25 @@ emptyKnownPeers = setPeerRecList $ KnownPeersRec []
 getScannedHeight :: (HasFiltersDB m, MonadLogger m) => Currency -> m (Maybe BlockHeight)
 getScannedHeight currency = do
   db <- readFiltersDb
-  stored <- getParsed currency "BlockHeight" db $ scannedHeightTxKey currency
+  stored <- getParsed currency "BlockHeight" db $ scannedHeightKey currency
   pure $ scannedHeightRecHeight <$> stored
 
 setScannedHeight :: (HasFiltersDB m, MonadLogger m) => Currency -> BlockHeight -> m ()
 setScannedHeight currency height = do
   db <- readFiltersDb
-  upsertItem currency db (scannedHeightTxKey currency) $ ScannedHeightRec height
+  write db def $ putItem currency (scannedHeightKey currency) $ ScannedHeightRec height
 
 initIndexerDb :: DB -> IO ()
 initIndexerDb db = do
   write db def $ putItem Currency.BTC knownPeersRecKey $ KnownPeersRec []
 
-addBlockInfo :: (HasBtcRollback m, HasFiltersDB m, HasIndexerDB m, MonadLogger m, MonadBaseControl IO m) => BlockInfo -> m ()
+addBlockInfo :: (HasBtcRollback m, HasFiltersDB m, HasIndexerDB m, HasUtxoDB m, MonadLogger m, MonadBaseControl IO m)
+  => BlockInfo -> m ()
 addBlockInfo (BlockInfo meta spent txinfos) = do
-  db <- readFiltersDb
-  write db def $ txInfosBatch <> metaInfosBatch <> heightWrite
+  dbf <- readFiltersDb
+  dbu <- readUtxoDb
+  write dbu def txInfosBatch
+  write dbf def $ metaInfosBatch <> heightWrite
   insertRollback cur $ RollbackRecItem txHashes prevHash (height -1)
   insertSpentTxUpdates cur spent
   setLastScannedBlock cur blkHash
@@ -128,13 +133,18 @@ addBlockInfo (BlockInfo meta spent txinfos) = do
     BlockMetaInfo cur height blkHash prevHash filt = meta
     txHashes       = txHash <$> txinfos
     txInfosBatch   = putTxInfosAsRecs cur height txinfos
-    metaInfosBatch = putItem cur (metaRecKey (cur, height)) $ BlockMetaRec blkHash filt
-    heightWrite    = putItem cur (scannedHeightTxKey cur) $ ScannedHeightRec height
+    metaInfosBatch = putItem cur (blockInfoRecKey (cur, height)) $ BlockInfoRec blkHash filt
+    heightWrite    = putItem cur (scannedHeightKey cur) $ ScannedHeightRec height
 
 setLastScannedBlock :: (HasIndexerDB m, MonadLogger m) => Currency -> ShortByteString -> m ()
 setLastScannedBlock currency blockHash = do
   db <- readIndexerDb
   upsertItem currency db (lastScannedBlockHeaderHashRecKey currency) $ LastScannedBlockHeaderHashRec blockHash
+
+deleteLastScannedBlock :: (HasIndexerDB m, MonadLogger m) => Currency -> m ()
+deleteLastScannedBlock currency = do
+  db <- readIndexerDb
+  write db def $ [LDB.Del $ lastScannedBlockHeaderHashRecKey currency]
 
 getLastScannedBlock :: (HasIndexerDB m, MonadLogger m) => Currency -> m (Maybe ShortByteString)
 getLastScannedBlock currency = do
@@ -148,8 +158,8 @@ addBlockMetaInfos currency infos = do
   db <- readFiltersDb
   write db def $ putItems currency keySelector valueSelector infos
   where
-    keySelector   info = metaRecKey (blockMetaCurrency info, blockMetaBlockHeight info)
-    valueSelector info = BlockMetaRec (blockMetaHeaderHash info) (blockMetaAddressFilter info)
+    keySelector   info = blockInfoRecKey (blockMetaCurrency info, blockMetaBlockHeight info)
+    valueSelector info = BlockInfoRec (blockMetaHeaderHash info) (blockMetaAddressFilter info)
 
 btcRollbackSize :: Int
 btcRollbackSize = 64
@@ -178,33 +188,33 @@ loadRollbackSequence cur = do
   mseq <- getParsed cur "loadRollbackSequence" idb $ rollbackKey cur
   pure $ fromMaybe (RollbackSequence mempty) mseq
 
-insertSpentTxUpdates :: (HasFiltersDB m, MonadLogger m, MonadBaseControl IO m) => Currency -> Map.Map TxHash Word32 -> m ()
+insertSpentTxUpdates :: (HasUtxoDB m, MonadLogger m, MonadBaseControl IO m) => Currency -> Map.Map TxHash Word32 -> m ()
 insertSpentTxUpdates _ outs = do
-  fdb <- readFiltersDb
+  udb <- readUtxoDb
   let outsl = mkChunks 100 $ Map.toList outs
-  upds <- fmap (mconcat . mconcat) $ mapConcurrently (traverse (mkupds fdb)) outsl
-  write fdb def upds
+  upds <- fmap (mconcat . mconcat) $ mapConcurrently (traverse (mkupds udb)) outsl
+  write udb def upds
   where
     maybe' mv c = maybe [] c mv
     either' ev c = either (const []) c ev
-    mkupds fdb (th, sp) = do
+    mkupds udb (th, sp) = do
       let k = txUnspentKey th
-      mraw <- get fdb def k
+      mraw <- get udb def k
       pure $ maybe' mraw $ \bs -> either' (egvDeserialize BTC bs) $ \(TxRecUnspent unsp) ->
         if unsp <= sp
           then [LDB.Del k, LDB.Del $ txBytesKey th]
           else [LDB.Put k $ egvSerialize BTC $ TxRecUnspent (unsp - sp)]
 
-performRollback :: (HasFiltersDB m, HasIndexerDB m, HasBtcRollback m, MonadLogger m) => Currency -> m Int
+performRollback :: (HasFiltersDB m, HasIndexerDB m, HasUtxoDB m, HasBtcRollback m, MonadLogger m) => Currency -> m Int
 performRollback cur = case cur of
   Currency.BTC -> performBtcRollback
   _ -> pure 0 --TODO
 
-performBtcRollback :: (HasFiltersDB m, HasIndexerDB m, HasBtcRollback m, MonadLogger m) => m Int
+performBtcRollback :: (HasFiltersDB m, HasUtxoDB m, HasIndexerDB m, HasBtcRollback m, MonadLogger m) => m Int
 performBtcRollback = do
   let cur = Currency.BTC
-  fdb <- readIndexerDb
-  idb <- readFiltersDb
+  udb <- readUtxoDb
+  idb <- readIndexerDb
   rollVar <- getBtcRollbackVar
   rse <- liftIO . readTVarIO $ rollVar
   let clearSeq = LDB.Put (rollbackKey cur) $ egvSerialize cur (RollbackSequence mempty)
@@ -216,7 +226,7 @@ performBtcRollback = do
 
   let spentTxIds = fold $ rollbackItemAdded <$> rse
   let dels = mconcat $ flip fmap spentTxIds $ \th -> [LDB.Del (txBytesKey th), LDB.Del (txHeightKey th)]
-  write fdb def dels
+  write udb def dels
   write idb def $ pure clearSeq
   liftIO $ atomically $ writeTVar rollVar mempty
   pure $ Seq.length rse

--- a/index-server/src/Ergvein/Index/Server/DB/Queries.hs
+++ b/index-server/src/Ergvein/Index/Server/DB/Queries.hs
@@ -15,6 +15,7 @@ module Ergvein.Index.Server.DB.Queries
   , getScannedHeight
   , setScannedHeight
   , addBlockMetaInfos
+  , getBlockInfoRec
   -- * Combined queries
   , addBlockInfo
   , addTxIndexInfo
@@ -241,3 +242,8 @@ addBtcTxIndexInfo :: (HasUtxoDB m, MonadLogger m) => TxIndexInfo -> m ()
 addBtcTxIndexInfo tinfo@TxIndexInfo{..} = do
   dbu <- readUtxoDb
   write dbu def $ putTxIndexInfoAsRec BTC tinfo
+
+getBlockInfoRec :: (HasFiltersDB m, MonadLogger m) => Currency -> BlockHeight -> m (Maybe BlockInfoRec)
+getBlockInfoRec c h = do
+  fdb <- readFiltersDb
+  getParsed c "getBlockInfoRec" fdb $ blockInfoRecKey (c,h)

--- a/index-server/src/Ergvein/Index/Server/DB/Schema/Filters.hs
+++ b/index-server/src/Ergvein/Index/Server/DB/Schema/Filters.hs
@@ -3,18 +3,10 @@ module Ergvein.Index.Server.DB.Schema.Filters
   (
     ScannedHeightRecKey(..)
   , ScannedHeightRec(..)
-  , BlockMetaRecKey(..)
-  , BlockMetaRec(..)
-  , TxRecBytes(..)
-  -- , TxRecMeta(..)
-  , TxRecHeight(..)
-  , TxRecUnspent(..)
-  , TxBytesKey(..)
-  , txBytesKey
-  , txHeightKey
-  , txUnspentKey
-  , scannedHeightTxKey
-  , metaRecKey
+  , BlockInfoRecKey(..)
+  , BlockInfoRec(..)
+  , scannedHeightKey
+  , blockInfoRecKey
   , unPrefixedKey
   , schemaVersionRecKey
   , schemaVersion
@@ -28,7 +20,6 @@ import Data.ByteString.Short (ShortByteString)
 import Data.FileEmbed
 import GHC.Generics
 import Data.Serialize (Serialize)
-import Data.Word
 
 import Ergvein.Index.Server.DB.Utils
 import Ergvein.Index.Server.DB.Serialize.Class
@@ -44,22 +35,45 @@ import qualified Data.ByteString.Builder as BB
 data KeyPrefix
   = SchemaVersion
   | ScannedHeight
-  | Meta
-  | TxBytes
-  | TxHeight
-  | TxUnspent
+  | BlockInfoTag
   deriving Enum
-
-schemaVersion :: ByteString
-schemaVersion = hash $(embedFile "src/Ergvein/Index/Server/DB/Schema/Filters.hs")
 
 keyString :: (Serialize k) => KeyPrefix -> k -> ByteString
 keyString keyPrefix key = (fromIntegral $ fromEnum keyPrefix) `BS.cons` S.encode key
 
---ScannedHeight
+-- ===========================================================================
+--           Schema Version
+-- ===========================================================================
 
-scannedHeightTxKey :: Currency -> ByteString
-scannedHeightTxKey = keyString ScannedHeight . ScannedHeightRecKey
+schemaVersion :: ByteString
+schemaVersion = hash $(embedFile "src/Ergvein/Index/Server/DB/Schema/Filters.hs")
+
+schemaVersionRecKey :: ByteString
+schemaVersionRecKey  = keyString SchemaVersion $ mempty @String
+
+-- ===========================================================================
+--           Block Info record
+-- ===========================================================================
+
+blockInfoRecKey :: (Currency, BlockHeight) -> ByteString
+blockInfoRecKey = keyString BlockInfoTag . uncurry BlockInfoRecKey
+
+data BlockInfoRecKey = BlockInfoRecKey
+  { blockInfoRecKeyCurrency     :: !Currency
+  , blockInfoRecKeyBlockHeight  :: !BlockHeight
+  } deriving (Generic, Show, Eq, Ord, Serialize)
+
+data BlockInfoRec = BlockInfoRec
+  { blockInfoRecHeaderHash     :: !ShortByteString
+  , blockInfoRecAddressFilter  :: !ByteString
+  } deriving (Generic, Show, Eq, Ord)
+
+-- ===========================================================================
+--           Scanned height record
+-- ===========================================================================
+
+scannedHeightKey :: Currency -> ByteString
+scannedHeightKey = keyString ScannedHeight . ScannedHeightRecKey
 
 data ScannedHeightRecKey = ScannedHeightRecKey
   { scannedHeightRecKey      :: !Currency
@@ -69,55 +83,6 @@ data ScannedHeightRec = ScannedHeightRec
   { scannedHeightRecHeight   :: !BlockHeight
   } deriving (Generic, Show, Eq, Ord)
 
---Tx
-
-txBytesKey :: TxHash -> ByteString
-txBytesKey = keyString TxBytes . TxBytesKey
-{-# INLINE txBytesKey #-}
-
-txHeightKey :: TxHash -> ByteString
-txHeightKey = keyString TxHeight . TxBytesKey
-{-# INLINE txHeightKey #-}
-
-txUnspentKey :: TxHash -> ByteString
-txUnspentKey = keyString TxUnspent . TxBytesKey
-{-# INLINE txUnspentKey #-}
-
-data TxBytesKey = TxBytesKey {unTxBytesKey :: !TxHash }
-  deriving (Generic, Show, Eq, Ord, Serialize)
-
-data TxRecBytes = TxRecBytes { unTxRecBytes :: !ByteString }
-  deriving (Generic, Show, Eq, Ord)
-
-data TxRecHeight = TxRecHeight { unTxRecHeight :: !Word32 }
-  deriving (Generic, Show, Eq, Ord)
-
-data TxRecUnspent = TxRecUnspent { unTxRecUnspent :: !Word32 }
-  deriving (Generic, Show, Eq, Ord)
-
---BlockMeta
-
-metaRecKey :: (Currency, BlockHeight) -> ByteString
-metaRecKey = keyString Meta . uncurry BlockMetaRecKey
-
-data BlockMetaRecKey = BlockMetaRecKey
-  { blockMetaRecKeyCurrency     :: !Currency
-  , blockMetaRecKeyBlockHeight  :: !BlockHeight
-  } deriving (Generic, Show, Eq, Ord, Serialize)
-
-data BlockMetaRec = BlockMetaRec
-  { blockMetaRecHeaderHash     :: !ShortByteString
-  , blockMetaRecAddressFilter  :: !ByteString
-  } deriving (Generic, Show, Eq, Ord)
-
---SchemaVersion
-
-schemaVersionRecKey :: ByteString
-schemaVersionRecKey  = keyString SchemaVersion $ mempty @String
-
-data SchemaVersionRec = Text  deriving (Generic, Show, Eq, Ord)
-
-
 -- ===========================================================================
 --           instances EgvSerialize
 -- ===========================================================================
@@ -126,24 +91,12 @@ instance EgvSerialize ScannedHeightRec where
   egvSerialize _ (ScannedHeightRec sh) = BL.toStrict . BB.toLazyByteString $ BB.word64LE sh
   egvDeserialize _ = parseOnly $ ScannedHeightRec <$> anyWord64le
 
-instance EgvSerialize TxRecBytes where
-  egvSerialize _ = BL.toStrict . BB.toLazyByteString . buildBS . unTxRecBytes
-  egvDeserialize _ = fmap TxRecBytes . parseOnly parseBS
-
-instance EgvSerialize TxRecHeight where
-  egvSerialize _ = BL.toStrict . BB.toLazyByteString . BB.word32LE . unTxRecHeight
-  egvDeserialize _ = fmap TxRecHeight . parseOnly anyWord32le
-
-instance EgvSerialize TxRecUnspent where
-  egvSerialize _ = BL.toStrict . BB.toLazyByteString . BB.word32LE . unTxRecUnspent
-  egvDeserialize _ = fmap TxRecUnspent . parseOnly anyWord32le
-
-instance EgvSerialize BlockMetaRec where
-  egvSerialize _ (BlockMetaRec hd filt) = BL.toStrict . BB.toLazyByteString $ let
+instance EgvSerialize BlockInfoRec where
+  egvSerialize _ (BlockInfoRec hd filt) = BL.toStrict . BB.toLazyByteString $ let
     len = fromIntegral $ BS.length filt
     in BB.shortByteString hd <> BB.word64LE len <> BB.byteString filt
   egvDeserialize cur = parseOnly $ do
-    blockMetaRecHeaderHash <- fmap BSS.toShort $ Parse.take (getBlockHashLength cur)
+    blockInfoRecHeaderHash <- fmap BSS.toShort $ Parse.take (getBlockHashLength cur)
     len <- fromIntegral <$> anyWord64le
-    blockMetaRecAddressFilter <- Parse.take len
-    pure BlockMetaRec{..}
+    blockInfoRecAddressFilter <- Parse.take len
+    pure BlockInfoRec{..}

--- a/index-server/src/Ergvein/Index/Server/DB/Schema/Utxo.hs
+++ b/index-server/src/Ergvein/Index/Server/DB/Schema/Utxo.hs
@@ -1,0 +1,94 @@
+{-# LANGUAGE DeriveAnyClass #-}
+module Ergvein.Index.Server.DB.Schema.Utxo
+  (
+    TxRecBytes(..)
+  , TxRecHeight(..)
+  , TxRecUnspent(..)
+  , TxBytesKey(..)
+  , txBytesKey
+  , txHeightKey
+  , txUnspentKey
+  , schemaVersion
+  , schemaVersionRecKey
+  ) where
+
+import Crypto.Hash.SHA256
+import Data.Attoparsec.Binary
+import Data.Attoparsec.ByteString as Parse
+import Data.ByteString (ByteString)
+import Data.FileEmbed
+import GHC.Generics
+import Data.Serialize (Serialize)
+import Data.Word
+
+import Ergvein.Index.Server.DB.Serialize.Class
+import Ergvein.Types.Transaction
+
+import qualified Data.ByteString         as BS
+import qualified Data.ByteString.Lazy    as BL
+import qualified Data.Serialize          as S
+import qualified Data.ByteString.Builder as BB
+
+data KeyPrefix
+  = SchemaVersion
+  | TxHeight
+  | TxBytes
+  | TxUnspent
+  deriving Enum
+
+keyString :: (Serialize k) => KeyPrefix -> k -> ByteString
+keyString keyPrefix key = (fromIntegral $ fromEnum keyPrefix) `BS.cons` S.encode key
+
+-- ===========================================================================
+--           Schema Version
+-- ===========================================================================
+
+schemaVersion :: ByteString
+schemaVersion = hash $(embedFile "src/Ergvein/Index/Server/DB/Schema/Utxo.hs")
+
+schemaVersionRecKey :: ByteString
+schemaVersionRecKey  = keyString SchemaVersion $ mempty @String
+
+-- ===========================================================================
+--           Tx records
+-- ===========================================================================
+
+txBytesKey :: TxHash -> ByteString
+txBytesKey = keyString TxBytes . TxBytesKey
+{-# INLINE txBytesKey #-}
+
+txHeightKey :: TxHash -> ByteString
+txHeightKey = keyString TxHeight . TxBytesKey
+{-# INLINE txHeightKey #-}
+
+txUnspentKey :: TxHash -> ByteString
+txUnspentKey = keyString TxUnspent . TxBytesKey
+{-# INLINE txUnspentKey #-}
+
+data TxBytesKey = TxBytesKey {unTxBytesKey :: !TxHash }
+  deriving (Generic, Show, Eq, Ord, Serialize)
+
+data TxRecBytes = TxRecBytes { unTxRecBytes :: !ByteString }
+  deriving (Generic, Show, Eq, Ord)
+
+data TxRecHeight = TxRecHeight { unTxRecHeight :: !Word32 }
+  deriving (Generic, Show, Eq, Ord)
+
+data TxRecUnspent = TxRecUnspent { unTxRecUnspent :: !Word32 }
+  deriving (Generic, Show, Eq, Ord)
+
+-- ===========================================================================
+--           instances EgvSerialize
+-- ===========================================================================
+
+instance EgvSerialize TxRecBytes where
+  egvSerialize _ = BL.toStrict . BB.toLazyByteString . buildBS . unTxRecBytes
+  egvDeserialize _ = fmap TxRecBytes . parseOnly parseBS
+
+instance EgvSerialize TxRecHeight where
+  egvSerialize _ = BL.toStrict . BB.toLazyByteString . BB.word32LE . unTxRecHeight
+  egvDeserialize _ = fmap TxRecHeight . parseOnly anyWord32le
+
+instance EgvSerialize TxRecUnspent where
+  egvSerialize _ = BL.toStrict . BB.toLazyByteString . BB.word32LE . unTxRecUnspent
+  egvDeserialize _ = fmap TxRecUnspent . parseOnly anyWord32le

--- a/index-server/src/Ergvein/Index/Server/DB/Serialize.hs
+++ b/index-server/src/Ergvein/Index/Server/DB/Serialize.hs
@@ -15,7 +15,7 @@ import Data.ByteString.Builder as BB
 import Data.Word
 
 import Ergvein.Index.Server.BlockchainScanning.Types
-import Ergvein.Index.Server.DB.Schema.Filters
+import Ergvein.Index.Server.DB.Schema.Utxo
 import Ergvein.Index.Server.DB.Serialize.Class
 import Ergvein.Types.Currency
 import Ergvein.Types.Transaction

--- a/index-server/src/Ergvein/Index/Server/DB/Serialize.hs
+++ b/index-server/src/Ergvein/Index/Server/DB/Serialize.hs
@@ -2,6 +2,7 @@ module Ergvein.Index.Server.DB.Serialize
   (
     EgvSerialize(..)
   , putTxInfosAsRecs
+  , putTxIndexInfoAsRec
   , serializeWord32
   , deserializeWord32
   ) where
@@ -44,3 +45,9 @@ putTxInfosAsRecs cur bheight infos = mconcat $ parMap rpar putI (force infos)
       , LDB.Put (txHeightKey txHash) $ egvSerialize cur $ TxRecHeight $ fromIntegral bheight
       , LDB.Put (txUnspentKey txHash) $ egvSerialize cur $ TxRecUnspent txOutputsCount
       ]
+
+putTxIndexInfoAsRec :: Currency -> TxIndexInfo -> LDB.WriteBatch
+putTxIndexInfoAsRec cur TxIndexInfo{..} = parMap rpar putI (force txIndexInfoIds)
+  where
+    val = egvSerialize cur $ TxRecHeight $ fromIntegral txIndexInfoHeight
+    putI th = LDB.Put (txHeightKey th) val

--- a/index-server/src/Ergvein/Index/Server/Monad.hs
+++ b/index-server/src/Ergvein/Index/Server/Monad.hs
@@ -45,6 +45,10 @@ instance HasIndexerDB ServerM where
   getIndexerDbVar = asks envIndexerDBContext
   {-# INLINE getIndexerDbVar #-}
 
+instance HasUtxoDB ServerM where
+  getUtxoDbVar = asks envUtxoDBContext
+  {-# INLINE getUtxoDbVar #-}
+
 instance HasBtcRollback ServerM where
   getBtcRollbackVar = asks envBtcRollback
   {-# INLINE getBtcRollbackVar #-}

--- a/index-server/src/Ergvein/Index/Server/TCPService/Conversions.hs
+++ b/index-server/src/Ergvein/Index/Server/TCPService/Conversions.hs
@@ -36,10 +36,10 @@ currencyToCurrencyCode code = do
       C.BTC   -> BTC
       C.ERGO  -> ERGO
 
-instance Conversion BlockMetaRec BlockFilter where
-  convert BlockMetaRec {..} = BlockFilter
-    { blockFilterBlockId = blockMetaRecHeaderHash
-    , blockFilterFilter  = blockMetaRecAddressFilter
+instance Conversion BlockInfoRec BlockFilter where
+  convert BlockInfoRec {..} = BlockFilter
+    { blockFilterBlockId = blockInfoRecHeaderHash
+    , blockFilterFilter  = blockInfoRecAddressFilter
     }
 
 

--- a/index-server/src/Ergvein/Index/Server/TCPService/MessageHandler.hs
+++ b/index-server/src/Ergvein/Index/Server/TCPService/MessageHandler.hs
@@ -27,12 +27,12 @@ import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import qualified Data.Vector as V
 
-getBlockMetaSlice :: Currency -> BlockHeight -> BlockHeight -> ServerM [BlockMetaRec]
+getBlockMetaSlice :: Currency -> BlockHeight -> BlockHeight -> ServerM [BlockInfoRec]
 getBlockMetaSlice currency startHeight amount = do
   db <- readFiltersDb
-  let start = BlockMetaRecKey currency $ startHeight
-      startBinary = metaRecKey (currency, startHeight)
-      end = BlockMetaRecKey currency $ startHeight + amount
+  let start = BlockInfoRecKey currency $ startHeight
+      startBinary = blockInfoRecKey (currency, startHeight)
+      end = BlockInfoRecKey currency $ startHeight + amount
 
   slice <- safeEntrySlice currency db startBinary start end
 

--- a/index-server/src/Ergvein/Index/Server/TxIndex.hs
+++ b/index-server/src/Ergvein/Index/Server/TxIndex.hs
@@ -1,0 +1,88 @@
+module Ergvein.Index.Server.TxIndex
+  (
+    txIndexApp
+  , newTxIndexEnv
+  ) where
+
+import Control.Concurrent.STM
+import Control.Monad.Catch
+import Control.Monad.IO.Unlift
+import Control.Monad.Logger
+import Control.Monad.Reader
+import Data.Time
+import System.DiskSpace
+import System.Posix.Signals
+
+import Ergvein.Index.Server.BlockchainScanning.Types
+import Ergvein.Index.Server.Config
+import Ergvein.Index.Server.DB.Queries
+import Ergvein.Index.Server.Dependencies
+import Ergvein.Index.Server.Metrics
+import Ergvein.Index.Server.TxIndex.Monad
+import Ergvein.Index.Server.TCPService.Conversions()
+import Ergvein.Index.Server.Utils
+import Ergvein.Text
+import Ergvein.Types.Currency
+import Ergvein.Types.Transaction
+
+import qualified Data.Text.IO as T
+import Ergvein.Index.Server.BlockchainScanning.Bitcoin (buildTxIndex, actualHeight)
+
+txIndexApp :: (MonadUnliftIO m, MonadLogger m) => TxIndexEnv -> m ()
+txIndexApp env = do
+  logInfoN $ "Server started at:" <> (showt . cfgServerPort $ envServerConfig env)
+  _ <- liftIO $ installHandler sigTERM (Catch onShutdown) Nothing
+  _ <- liftIO $ installHandler sigINT  (Catch onShutdown) Nothing
+  liftIO $ runTxIndexMIO env $ btcTxIndexBuilder 668617 Nothing
+  liftIO $ cancelableDelay (envShutdownFlag env) (-1)
+  where
+    onShutdown :: IO ()
+    onShutdown = do
+      T.putStrLn "Server stop signal recivied..."
+      T.putStrLn "service is stopping"
+      atomically $ writeTChan (envShutdownChannel env) True
+      atomically $ writeTVar (envShutdownFlag env) True
+
+btcTxIndexBuilder :: BlockHeight -> (Maybe BlockHeight) -> TxIndexM ()
+btcTxIndexBuilder hbeg mhend = indexIteration hbeg
+  where
+    blockIteration :: BlockHeight -> BlockHeight -> TxIndexM TxIndexInfo
+    blockIteration headBlockHeight blockHeight = do
+      now <- liftIO $ getCurrentTime
+      let percent = fromIntegral blockHeight / fromIntegral headBlockHeight :: Double
+      logInfoN $ "["<> showt (formatTime defaultTimeLocale "%Y-%m-%d %H:%M:%S" now) <> "] "
+        <> "Building index for <BTC> "
+        <> showt blockHeight <> " / " <> showt headBlockHeight <> " (" <> showf 2 (100*percent) <> "%)"
+        -- <> showt (length $ spentTxsHash bi)
+      buildTxIndex blockHeight
+
+    indexIteration :: BlockHeight -> TxIndexM ()
+    indexIteration current = do
+      shutdownFlag <- liftIO . readTVarIO =<< getShutdownFlag
+      unless shutdownFlag $ do
+        headBlockHeight <- actualHeight
+        let b = maybe True (current <=) mhend
+        when (current <= headBlockHeight && b) $ do
+          tryBlockInfo <- try $ blockIteration headBlockHeight current
+          enoughSpace <- isEnoughSpace
+          flg <- liftIO . readTVarIO =<< getShutdownFlag
+          case tryBlockInfo of
+            Right (txIndex@TxIndexInfo {..})
+              | flg -> logInfoN $ "Told to shut down"
+              | enoughSpace && not flg -> do
+                addTxIndexInfo BTC txIndex
+                indexIteration (succ current)
+              | otherwise -> logInfoN $ "Not enough available disc space to store block scan result"
+            -- FIXME: Are we swallowing ALL errors here???
+            Left (SomeException err) -> do
+              logInfoN $ "Error scanning " <> showt current <> " BTC " <> showt err
+              indexIteration (current - 1)
+
+isEnoughSpace :: TxIndexM Bool
+isEnoughSpace = do
+  path <- cfgUtxoDbPath <$> serverConfig
+  availSpace <- liftIO $ getAvailSpace path
+  setGauge availableSpaceGauge $ fromIntegral (availSpace - requiredAvailSpace)
+  pure $ requiredAvailSpace <= availSpace
+ where
+  requiredAvailSpace = 2^(30::Int) -- 1Gb

--- a/index-server/src/Ergvein/Index/Server/TxIndex/Monad.hs
+++ b/index-server/src/Ergvein/Index/Server/TxIndex/Monad.hs
@@ -1,0 +1,172 @@
+{-# LANGUAGE DerivingVia #-}
+module Ergvein.Index.Server.TxIndex.Monad
+  (
+    TxIndexM(..)
+  , TxIndexEnv(..)
+  , newTxIndexEnv
+  , runTxIndexMIO
+  , logOnException
+  ) where
+
+import Control.Concurrent
+import Control.Concurrent.STM
+import Control.Exception hiding (handle)
+import Control.Monad.Base
+import Control.Monad.Catch
+import Control.Monad.IO.Unlift
+import Control.Monad.Logger
+import Control.Monad.Reader
+import Control.Monad.Trans.Control
+import Data.Text (Text)
+import Data.Typeable
+import Database.LevelDB.Base
+import Network.HTTP.Client.TLS
+import Prometheus (MonadMonitor(..))
+import System.IO
+
+import Ergvein.Text
+import Ergvein.Index.Server.BlockchainScanning.BitcoinApiMonad
+import Ergvein.Index.Server.Config
+import Ergvein.Index.Server.DB
+import Ergvein.Index.Server.DB.Monad
+import Ergvein.Index.Server.TCPService.BTC
+import Ergvein.Index.Server.Dependencies
+
+import qualified Network.Bitcoin.Api.Client  as BitcoinApi
+import qualified Network.Haskoin.Constants   as HK
+import qualified Network.HTTP.Client         as HC
+
+data TxIndexEnv = TxIndexEnv
+    { envServerConfig             :: !Config
+    , envLogger                   :: !(Chan (Loc, LogSource, LogLevel, LogStr))
+    , envUtxoDBContext            :: !(MVar DB)
+    , envBitcoinNodeNetwork       :: !HK.Network
+    , envClientManager            :: !HC.Manager
+    , envBitcoinClient            :: !BitcoinApi.Client
+    , envBitcoinSocket            :: !BtcSocket
+    , envBitcoinSocketReconnect   :: !(IO ())
+    , envBtcConScheme             :: !(TVar BtcConnectionScheme)
+    -- , envBtcRollback              :: !(TVar (Seq.Seq RollbackRecItem))
+    , envShutdownFlag             :: !(TVar Bool)
+    , envShutdownChannel          :: !(TChan Bool)
+    }
+
+newtype TxIndexM a = TxIndexM { unTxIndexM :: ReaderT TxIndexEnv (LoggingT IO) a }
+  deriving (Functor, Applicative, Monad, MonadIO, MonadLogger, MonadReader TxIndexEnv, MonadThrow, MonadCatch, MonadMask, MonadBase IO)
+  -- To avoid orphan we unwrap LoggingT as its reader representation
+  deriving MonadMonitor via (ReaderT TxIndexEnv (ReaderT (Loc -> LogSource -> LogLevel -> LogStr -> IO ()) IO))
+
+newtype StMTxIndexM a = StMTxIndexM { unStMTxIndexM :: StM (ReaderT TxIndexEnv (LoggingT IO)) a }
+
+instance MonadBaseControl IO TxIndexM where
+  type StM TxIndexM a = StMTxIndexM a
+  liftBaseWith f = TxIndexM $ liftBaseWith $ \q -> f (fmap StMTxIndexM . q . unTxIndexM)
+  restoreM = TxIndexM . restoreM . unStMTxIndexM
+
+runTxIndexMIO :: TxIndexEnv -> TxIndexM a -> IO a
+runTxIndexMIO e = runChanLoggingT (envLogger e) . flip runReaderT e . unTxIndexM
+
+instance HasUtxoDB TxIndexM where
+  getUtxoDbVar = asks envUtxoDBContext
+  {-# INLINE getUtxoDbVar #-}
+
+instance HasBitcoinNodeNetwork TxIndexM where
+  currentBitcoinNetwork = asks envBitcoinNodeNetwork
+  {-# INLINE currentBitcoinNetwork #-}
+
+instance HasServerConfig TxIndexM where
+  serverConfig = asks envServerConfig
+  {-# INLINE serverConfig #-}
+
+instance BitcoinApiMonad TxIndexM where
+  nodeRpcCall f = liftIO . f =<< asks envBitcoinClient
+  {-# INLINE nodeRpcCall #-}
+  getSocketConn = asks envBitcoinSocket
+  {-# INLINE getSocketConn #-}
+  getBtcConnectionScheme = liftIO . readTVarIO =<< asks envBtcConScheme
+  {-# INLINE getBtcConnectionScheme #-}
+  restartSocketConn = do
+    f <- asks envBitcoinSocketReconnect
+    liftIO $ f
+
+-- instance HasClientManager TxIndexM where
+--   getClientManager = asks envClientManager
+--   {-# INLINE getClientManager #-}
+
+instance HasShutdownFlag TxIndexM where
+  getShutdownFlag = asks envShutdownFlag
+  {-# INLINE getShutdownFlag #-}
+
+instance MonadUnliftIO TxIndexM where
+  askUnliftIO = TxIndexM $ (\(UnliftIO run) -> UnliftIO $ run . unTxIndexM) <$> askUnliftIO
+  withRunInIO go = TxIndexM $ withRunInIO (\k -> go $ k . unTxIndexM)
+
+newTxIndexEnv :: (MonadIO m, MonadLogger m, MonadMask m, MonadBaseControl IO m)
+  => Bool               -- ^ flag, def True: wait for node connections to be up before finalizing the env
+  -> BitcoinApi.Client  -- ^ RPC connection to the bitcoin node
+  -> Config             -- ^ Contents of the config file
+  -> m TxIndexEnv
+newTxIndexEnv useTcp btcClient cfg@Config{..} = do
+    logger <- liftIO newChan
+    liftIO $ hSetBuffering stdout LineBuffering
+    void $ liftIO $ forkIO $ runStdoutLoggingT $ unChanLoggingT logger
+    utxoDBCntx     <- openDb True DBUtxo cfgUtxoDbPath
+    utxoDbVar      <- liftIO $ newMVar utxoDBCntx
+    tlsManager     <- liftIO $ newTlsManager
+    shutdownVar    <- liftIO $ newTVarIO False
+    shutdownChan   <- liftIO newTChanIO
+    btcRestartChan <- liftIO newTChanIO
+    btcConnVar     <- liftIO $ newTVarIO $ if useTcp then BtcConTCP else BtcConRPC
+    let bitcoinNodeNetwork = if cfgBTCNodeIsTestnet then HK.btcTest else HK.btc
+    btcsock <- if useTcp then do
+      btcsock <- connectBtc
+        bitcoinNodeNetwork
+        cfgBTCNodeTCPHost
+        (show cfgBTCNodeTCPPort)
+        shutdownVar
+        btcRestartChan
+      liftIO $ do
+        isUp <- atomically $ dupTChan $ btcSockOnActive btcsock
+        b <- readTVarIO $ btcSockIsActive btcsock
+        unless b $ fix $ \next -> do
+          b' <- atomically $ readTChan isUp
+          unless b' next
+      pure btcsock
+      else dummyBtcSock bitcoinNodeNetwork
+    pure TxIndexEnv
+      { envServerConfig            = cfg
+      , envLogger                  = logger
+      , envUtxoDBContext           = utxoDbVar
+      , envBitcoinNodeNetwork      = bitcoinNodeNetwork
+      , envClientManager           = tlsManager
+      , envBitcoinClient           = btcClient
+      , envBitcoinSocket           = btcsock
+      , envBitcoinSocketReconnect  = liftIO (atomically $ writeTChan btcRestartChan ())
+      , envBtcConScheme            = btcConnVar
+      -- , envBtcRollback             = btcSeqVar
+      , envShutdownFlag            = shutdownVar
+      , envShutdownChannel         = shutdownChan
+      }
+
+-- | Log exceptions at Error severity
+logOnException :: (
+    HasServerConfig m
+  , MonadIO m
+  , MonadLogger m
+  , MonadCatch m)
+  => Text -> m a -> m a
+logOnException threadName = handle logE
+  where
+    logE :: (
+        HasServerConfig m
+      , MonadIO m
+      , MonadLogger m
+      , MonadCatch m) => SomeException -> m b
+    logE e
+        | Just ThreadKilled <- fromException e = do
+            logInfoN $ "[" <> threadName <> "]: Killed normally by ThreadKilled"
+            throwM e
+        | SomeException eTy <- e = do
+            logErrorN $ "[" <> threadName <> "]: Killed by " <> showt (typeOf eTy) <> ". " <> showt eTy
+            liftIO $ threadDelay 1000000
+            throwM e

--- a/index-server/tests/Test/Generators.hs
+++ b/index-server/tests/Test/Generators.hs
@@ -1,27 +1,28 @@
 module Test.Generators where
 
 import Control.Monad (replicateM)
+import Data.Serialize (decode)
+import Network.Haskoin.Transaction hiding (TxHash)
+import qualified Network.Haskoin.Transaction as HK
 import Test.QuickCheck
 import Test.QuickCheck.Instances
-import Network.Haskoin.Transaction hiding (TxHash)
-import Data.Serialize (decode)
-import qualified Network.Haskoin.Transaction as HK
 
 
+import Ergvein.Index.Server.BlockchainScanning.Types
 import Ergvein.Index.Server.DB.Schema.Filters
 import Ergvein.Index.Server.DB.Schema.Indexer
-import Ergvein.Index.Server.BlockchainScanning.Types
+import Ergvein.Index.Server.DB.Schema.Utxo
 import Ergvein.Index.Server.PeerDiscovery.Types
 import Ergvein.Types.Transaction
 
-import qualified Data.List                  as L
-import qualified Data.Vector.Unboxed        as UV
-import qualified Data.Vector                as V
-import qualified Data.ByteString.Lazy       as BL
-import qualified Data.ByteString            as BS
-import qualified Data.ByteString.Short      as BSS
-import qualified Data.ByteString.Builder    as BB
 import qualified Data.Attoparsec.ByteString as AP
+import qualified Data.ByteString            as BS
+import qualified Data.ByteString.Builder    as BB
+import qualified Data.ByteString.Lazy       as BL
+import qualified Data.ByteString.Short      as BSS
+import qualified Data.List                  as L
+import qualified Data.Vector                as V
+import qualified Data.Vector.Unboxed        as UV
 
 --------------------------------------------------------------------------
 -- generators
@@ -47,7 +48,7 @@ arbitraryBSS32 = do
 instance Arbitrary TxHash where
   arbitrary = oneof [
       BtcTxHash <$> arbitrary
-    , ErgTxHash . ErgTxId <$> arbitraryBSS32
+    -- , ErgTxHash . ErgTxId <$> arbitraryBSS32 -- We do not support ERGO at the moment
     ]
 instance Arbitrary ScannedHeightRec where
   arbitrary = ScannedHeightRec <$> arbitrary
@@ -59,8 +60,8 @@ instance Arbitrary TxRecUnspent where
   arbitrary = TxRecUnspent <$> arbitrary
 instance Arbitrary TxInfo where
   arbitrary = TxInfo <$> arbitrary <*> arbitrary <*> arbitrary
-instance Arbitrary BlockMetaRec where
-  arbitrary = BlockMetaRec <$> arbitraryBSS32 <*> arbitrary
+instance Arbitrary BlockInfoRec where
+  arbitrary = BlockInfoRec <$> arbitraryBSS32 <*> arbitrary
 instance Arbitrary KnownPeerRecItem where
   arbitrary = KnownPeerRecItem <$> arbitrary <*> arbitrary
 instance Arbitrary KnownPeersRec where

--- a/index-server/tests/TestMain.hs
+++ b/index-server/tests/TestMain.hs
@@ -4,26 +4,27 @@ module Main where
 --------------------------------------------------------------------------
 -- imports
 
-import Network.Haskoin.Transaction
 import Control.DeepSeq
 import Control.Monad (replicateM)
 import Control.Parallel.Strategies
+import Network.Haskoin.Transaction
 import Test.QuickCheck
 import Test.QuickCheck.Instances
 
 import Test.Generators
 import Ergvein.Index.Server.BlockchainScanning.Types
-import Ergvein.Index.Server.DB.Serialize
 import Ergvein.Index.Server.DB.Schema.Filters
 import Ergvein.Index.Server.DB.Schema.Indexer
+import Ergvein.Index.Server.DB.Schema.Utxo
+import Ergvein.Index.Server.DB.Serialize
 import Ergvein.Types.Currency
 
-import qualified Data.Vector.Unboxed        as UV
-import qualified Data.Vector                as V
-import qualified Data.ByteString.Lazy       as BL
+import qualified Data.Attoparsec.ByteString as AP
 import qualified Data.ByteString            as BS
 import qualified Data.ByteString.Builder    as BB
-import qualified Data.Attoparsec.ByteString as AP
+import qualified Data.ByteString.Lazy       as BL
+import qualified Data.Vector                as V
+import qualified Data.Vector.Unboxed        as UV
 
 
 --------------------------------------------------------------------------
@@ -32,47 +33,47 @@ import qualified Data.Attoparsec.ByteString as AP
 --------------------------------------------------------------------------
 -- Serialize-deserialize
 
-_prop_encdec_lastScannedBlockHeaderHashRec :: LastScannedBlockHeaderHashRec -> Bool
-_prop_encdec_lastScannedBlockHeaderHashRec msg = either (const False) (msg ==) dec
+prop_encdec_lastScannedBlockHeaderHashRec :: LastScannedBlockHeaderHashRec -> Bool
+prop_encdec_lastScannedBlockHeaderHashRec msg = either (const False) (msg ==) dec
   where
     enc = egvSerialize BTC msg
     dec = egvDeserialize BTC enc
 
-_prop_encdec_ScannedHeightRec :: ScannedHeightRec -> Bool
-_prop_encdec_ScannedHeightRec msg = either (const False) (msg ==) dec
+prop_encdec_ScannedHeightRec :: ScannedHeightRec -> Bool
+prop_encdec_ScannedHeightRec msg = either (const False) (msg ==) dec
   where dec = egvDeserialize BTC $ egvSerialize BTC msg
-_prop_encdec_TxRecBytes :: TxRecBytes -> Bool
-_prop_encdec_TxRecBytes msg = either (const False) (msg ==) dec
+prop_encdec_TxRecBytes :: TxRecBytes -> Bool
+prop_encdec_TxRecBytes msg = either (const False) (msg ==) dec
   where dec = egvDeserialize BTC $ egvSerialize BTC msg
-_prop_encdec_TxRecHeight :: TxRecHeight -> Bool
-_prop_encdec_TxRecHeight msg = either (const False) (msg ==) dec
+prop_encdec_TxRecHeight :: TxRecHeight -> Bool
+prop_encdec_TxRecHeight msg = either (const False) (msg ==) dec
   where dec = egvDeserialize BTC $ egvSerialize BTC msg
-_prop_encdec_TxRecUnspent :: TxRecUnspent -> Bool
-_prop_encdec_TxRecUnspent msg = either (const False) (msg ==) dec
+prop_encdec_TxRecUnspent :: TxRecUnspent -> Bool
+prop_encdec_TxRecUnspent msg = either (const False) (msg ==) dec
   where dec = egvDeserialize BTC $ egvSerialize BTC msg
-_prop_encdec_BlockMetaRec :: BlockMetaRec -> Bool
-_prop_encdec_BlockMetaRec msg = either (const False) (msg ==) dec
+prop_encdec_BlockMetaRec :: BlockInfoRec -> Bool
+prop_encdec_BlockMetaRec msg = either (const False) (msg ==) dec
   where dec = egvDeserialize BTC $ egvSerialize BTC msg
-_prop_encdec_KnownPeerRecItem :: KnownPeerRecItem -> Bool
-_prop_encdec_KnownPeerRecItem msg = either (const False) (msg ==) dec
+prop_encdec_KnownPeerRecItem :: KnownPeerRecItem -> Bool
+prop_encdec_KnownPeerRecItem msg = either (const False) (msg ==) dec
   where dec = egvDeserialize BTC $ egvSerialize BTC msg
-_prop_encdec_KnownPeersRec :: KnownPeersRec -> Bool
-_prop_encdec_KnownPeersRec msg = either (const False) (msg ==) dec
+prop_encdec_KnownPeersRec :: KnownPeersRec -> Bool
+prop_encdec_KnownPeersRec msg = either (const False) (msg ==) dec
   where dec = egvDeserialize BTC $ egvSerialize BTC msg
-_prop_encdec_LastScannedBlockHeaderHashRec :: LastScannedBlockHeaderHashRec -> Bool
-_prop_encdec_LastScannedBlockHeaderHashRec msg = either (const False) (msg ==) dec
-  where dec = egvDeserialize BTC $ egvSerialize BTC msg
-
-_prop_encdec_RollbackSequence :: RollbackSequence -> Bool
-_prop_encdec_RollbackSequence msg = either (const False) (msg ==) dec
+prop_encdec_LastScannedBlockHeaderHashRec :: LastScannedBlockHeaderHashRec -> Bool
+prop_encdec_LastScannedBlockHeaderHashRec msg = either (const False) (msg ==) dec
   where dec = egvDeserialize BTC $ egvSerialize BTC msg
 
-_prop_encdec_TxIn :: TxIn -> Bool
-_prop_encdec_TxIn msg = either (const False) (msg ==) dec
+prop_encdec_RollbackSequence :: RollbackSequence -> Bool
+prop_encdec_RollbackSequence msg = either (const False) (msg ==) dec
   where dec = egvDeserialize BTC $ egvSerialize BTC msg
 
-_prop_encdec_TxOut :: TxOut -> Bool
-_prop_encdec_TxOut msg = either (const False) (msg ==) dec
+prop_encdec_TxIn :: TxIn -> Bool
+prop_encdec_TxIn msg = either (const False) (msg ==) dec
+  where dec = egvDeserialize BTC $ egvSerialize BTC msg
+
+prop_encdec_TxOut :: TxOut -> Bool
+prop_encdec_TxOut msg = either (const False) (msg ==) dec
   where dec = egvDeserialize BTC $ egvSerialize BTC msg
 --------------------------------------------------------------------------
 -- main

--- a/nix/service/ergvein-indexer.nix
+++ b/nix/service/ergvein-indexer.nix
@@ -90,6 +90,13 @@ in {
           Path to indexer database on filesystem.
         '';
       };
+      utxoPath = mkOption {
+        type = types.str;
+        default = if cfg.testnet then "/var/lib/ergvein-testnet/utxo" else "/var/lib/ergvein/utxo";
+        description = ''
+          Path to utxo database on filesystem.
+        '';
+      };
       testnet = mkOption {
         type = types.bool;
         default = false;
@@ -162,6 +169,7 @@ in {
           serverHostname           : ${cfg.nodeHostname}
           filtersDbPath            : ${cfg.filtersPath}
           indexerDbPath            : ${cfg.indexerPath}
+          utxoDbPath               : ${cfg.utxoPath}
           BTCNodeIsTestnet         : ${if cfg.testnet then "true" else "false"}
           BTCNodeHost              : ${cfg.btcHost}
           BTCNodePort              : ${toString cfg.btcPort}
@@ -225,6 +233,9 @@ in {
           fi
           if [ ! -d "${cfg.indexerPath}" ]; then
             mkdir -p ${cfg.indexerPath}
+          fi
+          if [ ! -d "${cfg.utxoPath}" ]; then
+            mkdir -p ${cfg.utxoPath}
           fi
         '';
         deps = [];


### PR DESCRIPTION
close #831 

### DB split
* Split Filters db into UTXO db + Filters Db
* Filters db stores only filters + the last scanned height
* UTXO db stores unspent transactions + transactions height index

### Robustness improvements
If something bad happens, like OOM, or sigKILL and the write is interrupted, we might have an inconsistent database.
The bad thing affects only the last scanned block: either it's height was written but not the Txs or its hash was written but not its height

* Perform ``unsafeClose`` for all databases while closing the server
  * DB closure is the last stage of server closure, just to be sure there are no writing threads alive
  * As an extra precaution, wait 5 more seconds for pending write batches to be committed to the DB

* Check database consistency on startup
  * Get the last scanned height from Filters db and the corresponding block from the BTC node
  * Check that fork detection and rollback info is consistent with the block. If not -- wipe the info, it is not crucial, since forks are extremely rare
  * Check that Filters db has the filter for the last block
  * Check that UTXO db has height information for all transactions in the last block
  * UTXO db should have raw transactions, but we don't check for it since it's not essential
  * If any check fails, assume the last block scan was interrupted and set decrease ``lastScannedHeight`` by 1 to rescan the corrupted block