### PR TITLE
Fix #838. Change RTS params for android build.

### DIFF
--- a/android-activity/cbits/HaskellActivity.c
+++ b/android-activity/cbits/HaskellActivity.c
@@ -201,7 +201,7 @@ JNIEXPORT int JNICALL Java_systems_obsidian_HaskellActivity_haskellStartMain (JN
   }
 
   static int argc = 5;
-  static char *argv[] = {"jsaddle", "+RTS", "-N2", "-I0", "-RTS"};
+  static char *argv[] = {"jsaddle", "+RTS", "-N", "-qm", "-RTS"};
 
   RtsConfig rts_opts = defaultRtsConfig;
   rts_opts.rts_opts_enabled = RtsOptsAll;
@@ -273,6 +273,7 @@ JNIEXPORT jint JNICALL JNI_OnLoad ( JavaVM *vm, void *reserved ) {
   HaskellActivity_jvm = vm;
 
   startLogger("HaskellActivity"); //TODO: Use the app name
+  init_runtime();
 
   return JNI_VERSION_1_6;
 }

--- a/android-activity/cbits/HaskellActivity.c
+++ b/android-activity/cbits/HaskellActivity.c
@@ -273,7 +273,6 @@ JNIEXPORT jint JNICALL JNI_OnLoad ( JavaVM *vm, void *reserved ) {
   HaskellActivity_jvm = vm;
 
   startLogger("HaskellActivity"); //TODO: Use the app name
-  init_runtime();
 
   return JNI_VERSION_1_6;
 }


### PR DESCRIPTION
I see missing freezes on my test devices. Increased number of capabilities (was 2), return idle GC, and forbid migration between caps (to free our main GUI thread).