### PR TITLE
Guard against bad indexers

### DIFF
--- a/index-protocol/src/Ergvein/Index/Protocol/Deserialization.hs
+++ b/index-protocol/src/Ergvein/Index/Protocol/Deserialization.hs
@@ -71,8 +71,8 @@ versionParser = do
   let mj   = S.toBits $ S.append pad $ S.take i10 $ S.drop i20 bs
   pure (mj,mn,p)
   where
-    i2,i6,i10,i20 :: Int
-    i2 = 2; i6 = 6 ; i10 = 10 ; i20 = 20
+    i6,i10,i20 :: Int
+    i6 = 6 ; i10 = 10 ; i20 = 20
     pad = S.replicate i6 False
 
 messageHeaderParser ::  Parser MessageHeader

--- a/index-protocol/src/Ergvein/Index/Protocol/Types.hs
+++ b/index-protocol/src/Ergvein/Index/Protocol/Types.hs
@@ -182,6 +182,9 @@ versionCurrSynced Version{..} c = flip UV.any versionScanBlocks $ \ScanBlock{..}
      scanBlockCurrency == c
   && (scanBlockHeight - scanBlockScanHeight) <= 1
 
+versionCurrsSynced :: Foldable t => Version -> t CurrencyCode -> Bool
+versionCurrsSynced v = all (versionCurrSynced v)
+
 data VersionACK = VersionACK
   deriving (Show, Eq)
 

--- a/index-protocol/src/Ergvein/Index/Protocol/Types.hs
+++ b/index-protocol/src/Ergvein/Index/Protocol/Types.hs
@@ -1,11 +1,12 @@
 module Ergvein.Index.Protocol.Types where
 
 import Conversion
-import Data.Attoparsec.ByteString
 import Data.Attoparsec.Binary
+import Data.Attoparsec.ByteString
 import Data.ByteString (ByteString)
 import Data.ByteString.Short (ShortByteString)
 import Data.Either
+import Data.List (nub)
 import Data.Map.Strict (Map)
 import Data.Vector.Unboxed.Deriving
 import Data.Word
@@ -166,6 +167,9 @@ data Version = Version
  -- versionCurrencies :: uint32 Amount of currencies blocks following the field. For clients it is 0.
   , versionScanBlocks :: !(UV.Vector ScanBlock)
   } deriving (Show, Eq)
+
+versionCurrencies :: Version -> [CurrencyCode]
+versionCurrencies Version{..} = nub . fmap scanBlockCurrency . UV.toList $ versionScanBlocks
 
 versionHasCurr :: Version -> CurrencyCode -> Bool
 versionHasCurr Version{..} c = UV.any ((c ==) . scanBlockCurrency) versionScanBlocks

--- a/index-protocol/src/Ergvein/Index/Protocol/Types.hs
+++ b/index-protocol/src/Ergvein/Index/Protocol/Types.hs
@@ -177,6 +177,11 @@ versionHasCurr Version{..} c = UV.any ((c ==) . scanBlockCurrency) versionScanBl
 versionHasCurrs :: Foldable t => Version -> t CurrencyCode -> Bool
 versionHasCurrs v = all (versionHasCurr v)
 
+versionCurrSynced :: Version -> CurrencyCode -> Bool
+versionCurrSynced Version{..} c = flip UV.any versionScanBlocks $ \ScanBlock{..} ->
+     scanBlockCurrency == c
+  && (scanBlockHeight - scanBlockScanHeight) <= 1
+
 data VersionACK = VersionACK
   deriving (Show, Eq)
 

--- a/index-server/src/Ergvein/Index/Server/TCPService/Conversions.hs
+++ b/index-server/src/Ergvein/Index/Server/TCPService/Conversions.hs
@@ -11,30 +11,15 @@ import Ergvein.Index.Server.Config
 
 import qualified Ergvein.Types.Currency as C
 
-
 currencyCodeToCurrency :: (Monad m, HasServerConfig m) => CurrencyCode -> m C.Currency
-currencyCodeToCurrency code = do
-  isTestnet <- cfgBTCNodeIsTestnet <$> serverConfig
-  pure $ (if isTestnet then testnet else mainnet) code
-  where
-    testnet = \case
-      TBTC   -> C.BTC
-      TERGO  -> C.ERGO
-    mainnet = \case
-      BTC   -> C.BTC
-      ERGO  -> C.ERGO
+currencyCodeToCurrency code = case codeToCurrency code of
+  Nothing -> fail $ "Unimplemented currency " <> show code
+  Just c -> pure c
 
 currencyToCurrencyCode :: (Monad m, HasServerConfig m) => C.Currency -> m CurrencyCode
 currencyToCurrencyCode code = do
   isTestnet <- cfgBTCNodeIsTestnet <$> serverConfig
-  pure $ (if isTestnet then testnet else mainnet) code
-  where
-    testnet = \case
-      C.BTC  -> TBTC
-      C.ERGO -> TERGO
-    mainnet = \case
-      C.BTC   -> BTC
-      C.ERGO  -> ERGO
+  pure $ currencyToCode isTestnet code
 
 instance Conversion BlockMetaRec BlockFilter where
   convert BlockMetaRec {..} = BlockFilter

--- a/wallet/src/Ergvein/Wallet/Indexer/Socket.hs
+++ b/wallet/src/Ergvein/Wallet/Indexer/Socket.hs
@@ -99,6 +99,7 @@ initIndexerConnection (NamedSockAddr sname sa) msgE = mdo
         _ -> Nothing
   heightsD <- foldDyn M.union M.empty setHE
 
+  statusD <- holdDyn IndexerOk $ leftmost [ IndexerWrongVersion <$ versionMismatchE ]
   pure $ IndexerConnection {
       indexConAddr = sa
     , indexConName = sname
@@ -107,7 +108,7 @@ initIndexerConnection (NamedSockAddr sname sa) msgE = mdo
     , indexConIsUp = shakeD
     , indexConRespE = respE
     , indexConHeight = heightsD
-    , indexConStatus = pure IndexerOk
+    , indexConStatus = statusD
     }
   where
     serializeMessage :: Message -> B.ByteString

--- a/wallet/src/Ergvein/Wallet/Indexer/Socket.hs
+++ b/wallet/src/Ergvein/Wallet/Indexer/Socket.hs
@@ -106,7 +106,7 @@ initIndexerConnection (NamedSockAddr sname sa) msgE = mdo
     , indexConOpensE = openE
     , indexConIsUp = shakeD
     , indexConRespE = respE
-    , indexerConHeight = heightsD
+    , indexConHeight = heightsD
     }
   where
     serializeMessage :: Message -> B.ByteString

--- a/wallet/src/Ergvein/Wallet/Indexer/Socket.hs
+++ b/wallet/src/Ergvein/Wallet/Indexer/Socket.hs
@@ -107,6 +107,7 @@ initIndexerConnection (NamedSockAddr sname sa) msgE = mdo
     , indexConIsUp = shakeD
     , indexConRespE = respE
     , indexConHeight = heightsD
+    , indexConStatus = pure IndexerOk
     }
   where
     serializeMessage :: Message -> B.ByteString

--- a/wallet/src/Ergvein/Wallet/Indexer/Socket.hs
+++ b/wallet/src/Ergvein/Wallet/Indexer/Socket.hs
@@ -1,4 +1,4 @@
-{-# OPTIONS_GHC -Wno-all #-}
+{-# LANGUAGE MultiWayIf #-}
 module Ergvein.Wallet.Indexer.Socket
   (
     initIndexerConnection
@@ -27,6 +27,7 @@ import Ergvein.Wallet.Monad.Client
 import Ergvein.Wallet.Monad.Prim
 import Ergvein.Wallet.Native
 import Ergvein.Wallet.Node.Socket
+import Ergvein.Wallet.Platform
 import Ergvein.Wallet.Settings
 import Ergvein.Wallet.Util
 
@@ -37,10 +38,25 @@ import qualified Data.ByteString.Lazy       as BL
 import qualified Data.Map.Strict            as M
 import qualified Data.Vector.Unboxed        as VU
 
+requiredCurrencies :: [CurrencyCode]
+requiredCurrencies = if isTestnet
+  then [TBTC] -- TODO: add ERGO here
+  else [BTC]
+
+hasRequiredCurrs :: Version -> Bool
+hasRequiredCurrs = (`versionHasCurrs` requiredCurrencies)
+
+requiredCurrsSynced :: Version -> Bool
+requiredCurrsSynced = (`versionCurrsSynced` requiredCurrencies)
+
 initIndexerConnection :: (MonadBaseConstr t m, MonadHasSettings t m) => NamedSockAddr -> Event t IndexerMsg ->  m (IndexerConnection t)
 initIndexerConnection (NamedSockAddr sname sa) msgE = mdo
   (versionMismatchE, versionMismatchFire) <- newTriggerEvent
+  (currenciesMismatchE, currenciesMismatchFire) <- newTriggerEvent
+  (currenciesNotSyncedE, currenciesNotSyncedFire) <- newTriggerEvent
   versionMismatchDE <- delay 0.2 versionMismatchE
+  currenciesMismatchDE <- delay 0.2 currenciesMismatchE
+  currenciesNotSyncedDE <- delay 0.2 currenciesNotSyncedE
   (msname, msport) <- liftIO $ getNameInfo [NI_NUMERICHOST, NI_NUMERICSERV] True True sa
   let peer = fromJust $ Peer <$> msname <*> msport
   let restartE = fforMaybe msgE $ \case
@@ -57,7 +73,7 @@ initIndexerConnection (NamedSockAddr sname sa) msgE = mdo
       _socketConfPeer   = peer
     , _socketConfSend   = fmap serializeMessage sendE
     , _socketConfPeeker = peekMessage sa
-    , _socketConfClose  = leftmost [closeE, versionMismatchDE]
+    , _socketConfClose  = leftmost [closeE, versionMismatchDE, currenciesMismatchDE, currenciesNotSyncedDE]
     , _socketConfReopen = Just (1, 2) -- reconnect after 1 seconds 2 retries
     , _socketConfProxy  = proxyD
     }
@@ -68,14 +84,21 @@ initIndexerConnection (NamedSockAddr sname sa) msgE = mdo
       nodeLog sa $ "The remote version is not compatible with our version " <> showt protocolVersion
       liftIO $ versionMismatchFire ()
       pure Nothing
-    MVersion Version{..} -> do
+    MVersion v@Version{..} -> do
       nodeLog sa $ "Received version: " <> showt versionVersion
-      if protocolVersion `isCompatible` versionVersion
-        then pure $ Just (MVersionACK VersionACK)
-        else do
-          nodeLog sa $ "The reported remote version " <> showt versionVersion <> " is not compatible with our version " <> showt protocolVersion
-          liftIO $ versionMismatchFire ()
-          pure Nothing
+      if | not $ protocolVersion `isCompatible` versionVersion -> do
+            nodeLog sa $ "The reported remote version " <> showt versionVersion <> " is not compatible with our version " <> showt protocolVersion
+            liftIO $ versionMismatchFire ()
+            pure Nothing
+         | not $ hasRequiredCurrs v -> do
+            nodeLog sa $ "The indexer doesn't support required currencies " <> showt requiredCurrencies <> ", but got: " <> showt (versionCurrencies v)
+            liftIO $ currenciesMismatchFire ()
+            pure Nothing
+         | not $ requiredCurrsSynced v -> do
+           nodeLog sa $ "The indexer is not fully synced for currencies " <> showt requiredCurrencies
+           liftIO $ currenciesNotSyncedFire ()
+           pure Nothing
+         | otherwise -> pure $ Just (MVersionACK VersionACK)
     MPing nonce -> pure $ Just $ MPong nonce
     _ -> pure Nothing
   let sendE = leftmost [handshakeE, hsRespE, gate (current shakeD) reqE]
@@ -99,7 +122,10 @@ initIndexerConnection (NamedSockAddr sname sa) msgE = mdo
         _ -> Nothing
   heightsD <- foldDyn M.union M.empty setHE
 
-  statusD <- holdDyn IndexerOk $ leftmost [ IndexerWrongVersion <$ versionMismatchE ]
+  statusD <- holdDyn IndexerOk $ leftmost [
+      IndexerWrongVersion <$ versionMismatchE
+    , IndexerMissingCurrencies <$ currenciesMismatchE
+    , IndexerNotSynced <$ currenciesNotSyncedE ]
   pure $ IndexerConnection {
       indexConAddr = sa
     , indexConName = sname

--- a/wallet/src/Ergvein/Wallet/Localization/Settings.hs
+++ b/wallet/src/Ergvein/Wallet/Localization/Settings.hs
@@ -6,11 +6,12 @@ module Ergvein.Wallet.Localization.Settings(
   ) where
 
 import Data.Time
+import Ergvein.Index.Protocol.Types
 import Ergvein.Text
 import Ergvein.Types.Currency
 import Ergvein.Types.Transaction
-import Ergvein.Wallet.Language
 import Ergvein.Wallet.Elements.Input.Class
+import Ergvein.Wallet.Language
 import Ergvein.Wallet.Localization.Input
 import Ergvein.Wallet.Localization.IP
 
@@ -144,6 +145,9 @@ data NetSetupStrings
   | NSSLatency NominalDiffTime
   | NSSIndexerHeight BlockHeight
   | NSSOffline
+  | NSSWrongVersion (Maybe ProtocolVersion)
+  | NSSMissingCurrencies
+  | NSSNotSynced
   | NSSRefresh
   | NSSPing
   | NSSPingAll
@@ -176,6 +180,9 @@ instance LocalizedPrint NetSetupStrings where
       NSSLatency lat  -> "Latency: " <> showt lat
       NSSIndexerHeight h -> "Height: " <> showt h
       NSSOffline      -> "Offline"
+      NSSWrongVersion v -> "Indexer has incompatible version " <> maybe "" showt v
+      NSSMissingCurrencies -> "Indexer doesn't support all currencies"
+      NSSNotSynced    -> "Indexer not fully synced"
       NSSRefresh      -> "Refresh"
       NSSPing         -> "Ping"
       NSSDisable      -> "Disable"
@@ -205,6 +212,9 @@ instance LocalizedPrint NetSetupStrings where
       NSSLatency lat  -> "Задержка: " <> showt lat
       NSSIndexerHeight h -> "Высота: " <> showt h
       NSSOffline      -> "Оффлайн"
+      NSSWrongVersion v -> "Индексатор несовместимой версии " <> maybe "" showt v
+      NSSMissingCurrencies -> "Индексатор не поддерживает все валюты"
+      NSSNotSynced    -> "Не полностью синхронизирован"
       NSSRefresh      -> "Обновить"
       NSSPing         -> "Запросить статус"
       NSSDisable      -> "Отключить"

--- a/wallet/src/Ergvein/Wallet/Monad/Auth.hs
+++ b/wallet/src/Ergvein/Wallet/Monad/Auth.hs
@@ -87,6 +87,7 @@ data Env t = Env {
 , env'inactiveAddrs   :: !(ExternalRef t (S.Set NamedSockAddr))
 , env'activeAddrs     :: !(ExternalRef t (S.Set NamedSockAddr))
 , env'indexConmap     :: !(ExternalRef t (Map SockAddr (IndexerConnection t)))
+, env'indexStatus     :: !(ExternalRef t (Map SockAddr IndexerStatus))
 , env'reqUrlNum       :: !(ExternalRef t (Int, Int))
 , env'actUrlNum       :: !(ExternalRef t Int)
 , env'timeout         :: !(ExternalRef t NominalDiffTime)
@@ -183,6 +184,8 @@ instance MonadBaseConstr t m => MonadIndexClient t (ErgveinM t m) where
   {-# INLINE getArchivedAddrsRef #-}
   getActiveConnsRef = asks env'indexConmap
   {-# INLINE getActiveConnsRef #-}
+  getStatusConnsRef = asks env'indexStatus
+  {-# INLINE getStatusConnsRef #-}
   getInactiveAddrsRef = asks env'inactiveAddrs
   {-# INLINE getInactiveAddrsRef #-}
   getActiveUrlsNumRef = asks env'actUrlNum
@@ -331,6 +334,7 @@ liftAuth ma0 ma = mdo
         inactiveUrls    <- getInactiveAddrsRef
         actvieAddrsRef  <- getActiveAddrsRef
         indexConmapRef  <- getActiveConnsRef
+        indexStatusRef  <- getStatusConnsRef
         reqUrlNumRef    <- getRequiredUrlNumRef
         actUrlNumRef    <- getActiveUrlsNumRef
         timeoutRef      <- getRequestTimeoutRef
@@ -384,6 +388,7 @@ liftAuth ma0 ma = mdo
               , env'inactiveAddrs = inactiveUrls
               , env'activeAddrs = actvieAddrsRef
               , env'indexConmap = indexConmapRef
+              , env'indexStatus = indexStatusRef
               , env'reqUrlNum = reqUrlNumRef
               , env'actUrlNum = actUrlNumRef
               , env'timeout = timeoutRef

--- a/wallet/src/Ergvein/Wallet/Monad/Client.hs
+++ b/wallet/src/Ergvein/Wallet/Monad/Client.hs
@@ -57,7 +57,7 @@ data IndexerConnection t = IndexerConnection {
 , indexConStatus :: !(Dynamic t IndexerStatus)
 }
 
-data IndexerStatus = IndexerOk | IndexerNotSynced | IndexerWrongVersion | IndexerWrongNetwork
+data IndexerStatus = IndexerOk | IndexerNotSynced | IndexerWrongVersion | IndexerMissingCurrencies
   deriving (Eq, Ord, Show, Read, Generic)
 
 data IndexerMsg = IndexerClose | IndexerRestart | IndexerMsg Message

--- a/wallet/src/Ergvein/Wallet/Monad/Client.hs
+++ b/wallet/src/Ergvein/Wallet/Monad/Client.hs
@@ -1,6 +1,7 @@
 module Ergvein.Wallet.Monad.Client (
     MonadIndexClient(..)
   , IndexerConnection(..)
+  , IndexerStatus(..)
   , IndexerMsg(..)
   , IndexReqSelector
   , getArchivedUrlsD
@@ -29,6 +30,7 @@ import Data.Map.Strict (Map)
 import Data.Set (Set)
 import Data.Text (Text)
 import Data.Time(NominalDiffTime, getCurrentTime, diffUTCTime)
+import GHC.Generics
 import Network.Socket (SockAddr)
 import Reflex
 import Reflex.ExternalRef
@@ -52,7 +54,11 @@ data IndexerConnection t = IndexerConnection {
 , indexConIsUp :: !(Dynamic t Bool)
 , indexConRespE :: !(Event t Message)
 , indexConHeight :: !(Dynamic t (Map Currency BlockHeight))
+, indexConStatus :: !(Dynamic t IndexerStatus)
 }
+
+data IndexerStatus = IndexerOk | IndexerNotSynced | IndexerWrongVersion | IndexerWrongNetwork
+  deriving (Eq, Ord, Show, Read, Generic)
 
 data IndexerMsg = IndexerClose | IndexerRestart | IndexerMsg Message
 

--- a/wallet/src/Ergvein/Wallet/Monad/Client.hs
+++ b/wallet/src/Ergvein/Wallet/Monad/Client.hs
@@ -18,6 +18,7 @@ module Ergvein.Wallet.Monad.Client (
   , indexersAverageLatNumWidget
   , requestIndexerWhenOpen
   , indexerStatusUpdater
+  , indexerLastStatus
   -- * Reexports
   , SockAddr
   ) where
@@ -316,3 +317,9 @@ indexerStatusUpdater IndexerConnection{..} = do
   r <- getStatusConnsRef
   performEvent_ $ ffor e $ \status -> do
     modifyExternalRef r $ \m -> (M.insert indexConAddr status m, ())
+
+-- | Get cached status of indexer even it is disconnected
+indexerLastStatus :: forall t m . MonadIndexClient t m => SockAddr -> m (Dynamic t (Maybe IndexerStatus))
+indexerLastStatus addr = do
+  md <- externalRefDynamic =<< getStatusConnsRef
+  pure $ M.lookup addr <$> md

--- a/wallet/src/Ergvein/Wallet/Monad/Client.hs
+++ b/wallet/src/Ergvein/Wallet/Monad/Client.hs
@@ -51,7 +51,7 @@ data IndexerConnection t = IndexerConnection {
 , indexConOpensE :: !(Event t ())
 , indexConIsUp :: !(Dynamic t Bool)
 , indexConRespE :: !(Event t Message)
-, indexerConHeight :: !(Dynamic t (Map Currency BlockHeight))
+, indexConHeight :: !(Dynamic t (Map Currency BlockHeight))
 }
 
 data IndexerMsg = IndexerClose | IndexerRestart | IndexerMsg Message

--- a/wallet/src/Ergvein/Wallet/Monad/Client.hs
+++ b/wallet/src/Ergvein/Wallet/Monad/Client.hs
@@ -36,7 +36,7 @@ import Network.Socket (SockAddr)
 import Reflex
 import Reflex.ExternalRef
 
-import Ergvein.Index.Protocol.Types (Message(..))
+import Ergvein.Index.Protocol.Types (Message(..), ProtocolVersion)
 import Ergvein.Types.Currency
 import Ergvein.Types.Transaction
 import Ergvein.Wallet.Monad.Async
@@ -58,7 +58,7 @@ data IndexerConnection t = IndexerConnection {
 , indexConStatus :: !(Dynamic t IndexerStatus)
 }
 
-data IndexerStatus = IndexerOk | IndexerNotSynced | IndexerWrongVersion | IndexerMissingCurrencies
+data IndexerStatus = IndexerOk | IndexerNotSynced | IndexerWrongVersion !(Maybe ProtocolVersion) | IndexerMissingCurrencies
   deriving (Eq, Ord, Show, Read, Generic)
 
 data IndexerMsg = IndexerClose | IndexerRestart | IndexerMsg Message

--- a/wallet/src/Ergvein/Wallet/Monad/Client.hs
+++ b/wallet/src/Ergvein/Wallet/Monad/Client.hs
@@ -75,6 +75,8 @@ class MonadBaseConstr t m => MonadIndexClient t m | m -> t where
   getArchivedAddrsRef :: m (ExternalRef t (Set NamedSockAddr))
   -- | Internal method to get reference to indexers
   getActiveConnsRef :: m (ExternalRef t (Map SockAddr (IndexerConnection t)))
+  -- | Internal method to get last status of indexer
+  getStatusConnsRef :: m (ExternalRef t (Map SockAddr IndexerStatus))
   -- | Get deactivated urls' reference. Internal
   getInactiveAddrsRef :: m (ExternalRef t (Set NamedSockAddr))
   -- | Get reference to the minimal number of active urls. Internal

--- a/wallet/src/Ergvein/Wallet/Monad/Front.hs
+++ b/wallet/src/Ergvein/Wallet/Monad/Front.hs
@@ -312,7 +312,7 @@ getOpenSyncedConns cur = do
     logWrite $ "Connection " <> showt (indexConAddr con) <> " is up: " <> showt isUp
     walletHeight <- sampleDyn walletHeightD
     if not isUp then pure Nothing else do
-      indexerHeight <- fmap (M.lookup cur) $ sampleDyn $ indexerConHeight con
+      indexerHeight <- fmap (M.lookup cur) $ sampleDyn $ indexConHeight con
       logWrite $ "Wallet height " <> showt walletHeight
       logWrite $ "Indexer height " <> showt indexerHeight
       pure $ case (walletHeight, fromIntegral <$> indexerHeight) of

--- a/wallet/src/Ergvein/Wallet/Monad/Unauth.hs
+++ b/wallet/src/Ergvein/Wallet/Monad/Unauth.hs
@@ -50,6 +50,7 @@ data UnauthEnv t = UnauthEnv {
 , unauth'inactiveAddrs   :: !(ExternalRef t (S.Set NamedSockAddr))
 , unauth'activeAddrs     :: !(ExternalRef t (S.Set NamedSockAddr))
 , unauth'indexConmap     :: !(ExternalRef t (Map SockAddr (IndexerConnection t)))
+, unauth'indexStatus     :: !(ExternalRef t (Map SockAddr IndexerStatus))
 , unauth'reqUrlNum       :: !(ExternalRef t (Int, Int))
 , unauth'actUrlNum       :: !(ExternalRef t Int)
 , unauth'timeout         :: !(ExternalRef t NominalDiffTime)
@@ -130,6 +131,8 @@ instance MonadBaseConstr t m => MonadIndexClient t (UnauthM t m) where
   {-# INLINE getArchivedAddrsRef #-}
   getActiveConnsRef = asks unauth'indexConmap
   {-# INLINE getActiveConnsRef #-}
+  getStatusConnsRef = asks unauth'indexStatus
+  {-# INLINE getStatusConnsRef #-}
   getInactiveAddrsRef = asks unauth'inactiveAddrs
   {-# INLINE getInactiveAddrsRef #-}
   getActiveUrlsNumRef = asks unauth'actUrlNum
@@ -170,6 +173,7 @@ newEnv settings uiChan = do
   inactiveUrls    <- newExternalRef . S.fromList =<< parseSockAddrs rs (settingsDeactivatedAddrs settings)
   actvieAddrsRef  <- newExternalRef $ S.fromList socadrs
   indexConmapRef  <- newExternalRef $ M.empty
+  indexStatusRef  <- newExternalRef $ M.empty
   reqUrlNumRef    <- newExternalRef $ settingsReqUrlNum settings
   actUrlNumRef    <- newExternalRef $ settingsActUrlNum settings
   timeoutRef      <- newExternalRef $ settingsReqTimeout settings
@@ -195,6 +199,7 @@ newEnv settings uiChan = do
         , unauth'inactiveAddrs    = inactiveUrls
         , unauth'activeAddrs      = actvieAddrsRef
         , unauth'indexConmap      = indexConmapRef
+        , unauth'indexStatus      = indexStatusRef
         , unauth'reqUrlNum        = reqUrlNumRef
         , unauth'actUrlNum        = actUrlNumRef
         , unauth'timeout          = timeoutRef

--- a/wallet/src/Ergvein/Wallet/Page/Settings/Network.hs
+++ b/wallet/src/Ergvein/Wallet/Page/Settings/Network.hs
@@ -160,7 +160,12 @@ renderActive nsa refrE mconn = mdo
         elAttr "span" offclass $ elClass "i" "fas fa-circle" $ pure ()
         divClass "mt-a mb-a network-name-txt" $ text $ namedAddrName nsa
         editBtn
-      descrOption NSSOffline
+      stD <- indexerLastStatus $ namedAddrSock nsa
+      widgetHoldDyn $ ffor stD $ \case
+        Just (IndexerWrongVersion v) -> descrOption $ NSSWrongVersion v
+        Just IndexerMissingCurrencies -> descrOption NSSMissingCurrencies
+        Just IndexerNotSynced -> descrOption NSSNotSynced
+        _ -> descrOption NSSOffline
       pure tglE'
     Just conn -> do
       let clsUnauthD = ffor (indexConIsUp conn) $ \up -> if up then onclass else offclass

--- a/wallet/src/Ergvein/Wallet/Page/Settings/Network.hs
+++ b/wallet/src/Ergvein/Wallet/Page/Settings/Network.hs
@@ -164,7 +164,7 @@ renderActive nsa refrE mconn = mdo
       pure tglE'
     Just conn -> do
       let clsUnauthD = ffor (indexConIsUp conn) $ \up -> if up then onclass else offclass
-      let heightD = fmap (M.lookup BTC) $ indexerConHeight conn
+      let heightD = fmap (M.lookup BTC) $ indexConHeight conn
       clsD <- fmap join $ liftAuth (pure clsUnauthD) $ do
         hD <- getCurrentHeight BTC
         pure $ do

--- a/wallet/src/Ergvein/Wallet/Worker/Indexer.hs
+++ b/wallet/src/Ergvein/Wallet/Worker/Indexer.hs
@@ -36,6 +36,7 @@ indexerNodeController initAddrs = mdo
     let reqE = select sel $ Const2 u
     conn <- initIndexerConnection nsa reqE
     modifyExternalRef connRef $ \cm -> (M.insert u conn cm, ())
+    indexerStatusUpdater conn
 
     -- Everything below thsi line is handling the closure of a connection
     -- the event the socket fires when it wants to be closed


### PR DESCRIPTION
We don't use:
* Indexers with incompatible version 
* Indexers with wrong set of currencies (testnet/mainnet is taken in account)
* Indexers that reports that they are not synced for required set of currencies

![image](https://user-images.githubusercontent.com/2116167/106979294-179b0c00-676f-11eb-92c1-c46c7c0954a0.png)
