### PR TITLE
Lock database instead of blocking it during reopening

### DIFF
--- a/index-server/src/Ergvein/Index/Server/DB/Wrapper.hs
+++ b/index-server/src/Ergvein/Index/Server/DB/Wrapper.hs
@@ -8,8 +8,8 @@
 module Ergvein.Index.Server.DB.Wrapper
   ( LevelDB
   , openLevelDB
+  , reopenLevelDB
   , closeLevelDB
-  , moveLevelDbHandle
     -- * Wrapped operations
   , writeLDB
   , getLDB
@@ -27,32 +27,41 @@ import Database.LevelDB.Internal (unsafeClose)
 import Database.LevelDB.Streaming (entrySlice,Entry,KeyRange,Direction)
 import qualified Database.LevelDB.Streaming as Stream
 
+
+
 -- | Connection to database. Actual connection is stored inside @MVar@
 -- and @Nothing@ is stored on when connection is closed. This way user
 -- won't be able to use now invalid connection,
 data LevelDB = LevelDB
-  { dbHandle :: TVar (Maybe DB) -- ^ Database handle.
-  , dbActive :: TVar Int        -- ^ Number of active DB operations
+  { dbHandle   :: TVar DBState -- ^ Database handle.
+  , dbActive   :: TVar Int     -- ^ Number of active DB operations
+  , dbFilePath :: FilePath
+  , dbOptions  :: Options
   }
+
+data DBState
+  = DbOpen   !DB  -- Database is open
+  | DbClosed      -- Database is closed. Attempt to use it will throw
+  | DbCloseLocked -- Database is closed and locked. Attempts to use it
+                  -- will block. This state is used for reopening DB
 
 -- | Open handle to a database
 openLevelDB :: MonadIO m => FilePath -> Options -> m LevelDB
 openLevelDB path opt = liftIO $ do
   dbActive <- newTVarIO 0
-  dbHandle <- newTVarIO . Just =<< open path opt
-  pure LevelDB{..}
+  dbHandle <- newTVarIO . DbOpen =<< open path opt
+  pure LevelDB{ dbFilePath = path
+              , dbOptions  = opt
+              , ..
+              }
 
--- | Close and then immediately reopen database
-moveLevelDbHandle :: MonadIO m => LevelDB -> LevelDB -> m ()
-moveLevelDbHandle src dst = liftIO $ do
-  -- First close destination database
-  closeLevelDB dst
-  -- Move new one.
-  atomically $ do
-    writeTVar (dbHandle dst) =<< readTVar (dbHandle src)
-    writeTVar (dbActive dst) =<< readTVar (dbActive src)
-    writeTVar (dbHandle src) Nothing
-    writeTVar (dbActive src) 0
+-- | Close and then open database again.
+reopenLevelDB :: MonadIO m => LevelDB -> m ()
+reopenLevelDB LevelDB{..} = liftIO $ do
+  mdb <- atomically $ readTVar dbHandle <* writeTVar dbHandle DbCloseLocked
+  closeHandle dbActive mdb
+  -- reopen database
+  atomically . writeTVar dbHandle . DbOpen =<< open dbFilePath dbOptions
 
 -- | Close handle. After close it's no longer usable and any database
 -- operation which uses this handle will throw exception.
@@ -60,21 +69,25 @@ closeLevelDB :: MonadIO m => LevelDB -> m ()
 -- FIXME: Masking???
 closeLevelDB LevelDB{..} = liftIO $ do
   -- First mark database as closed so no new transaction could be started
-  mdb <- atomically $ readTVar dbHandle <* writeTVar dbHandle Nothing
-  case mdb of
-    Nothing -> pure ()
-    Just db -> do
-      -- Wait until all requests are finished then close database
-      atomically $ check . (==0) =<< readTVar dbActive
-      unsafeClose db
+  mdb <- atomically $ readTVar dbHandle <* writeTVar dbHandle DbClosed
+  closeHandle dbActive mdb
 
+closeHandle :: TVar Int -> DBState -> IO ()
+closeHandle active = \case
+    DbClosed      -> pure ()
+    DbCloseLocked -> pure ()
+    DbOpen   db   -> do
+      -- Wait until all requests are finished then close database
+      atomically $ check . (==0) =<< readTVar active
+      unsafeClose db
 
 usingLevelDB :: MonadIO m => LevelDB -> (DB -> IO a) -> m a
 usingLevelDB LevelDB{..} = liftIO . bracket ini fini
   where
     ini = atomically $ readTVar dbHandle >>= \case
-      Nothing -> error "LevelDB: Database is closed"
-      Just db -> db <$ modifyTVar' dbActive succ
+      DbOpen   db   -> db <$ modifyTVar' dbActive succ
+      DbClosed      -> error "LevelDB: Database is closed"
+      DbCloseLocked -> retry
     fini _ = atomically $ modifyTVar' dbActive pred
 
 

--- a/index-server/src/Ergvein/Index/Server/Environment.hs
+++ b/index-server/src/Ergvein/Index/Server/Environment.hs
@@ -1,3 +1,4 @@
+
 {-# OPTIONS_GHC -Wall #-}
 module Ergvein.Index.Server.Environment where
 
@@ -190,15 +191,9 @@ logOnException threadName = handle logE
               fdb <- getFiltersDb
               idb <- getIndexerDb
               udb <- getUtxoDb
-              closeLevelDB fdb
-              closeLevelDB idb
-              closeLevelDB udb
-              fdb' <- openDb False DBFilters cfgFiltersDbPath
-              idb' <- openDb False DBIndexer cfgIndexerDbPath
-              udb' <- openDb False DBUtxo    cfgUtxoDbPath
-              moveLevelDbHandle fdb' fdb
-              moveLevelDbHandle idb' idb
-              moveLevelDbHandle udb' udb
+              reopenLevelDB fdb
+              reopenLevelDB idb
+              reopenLevelDB udb
               logInfoN' "Reopened the db. Resume as usual"
             else
               logErrorN' $ "Killed by IOException. " <> showt ioe


### PR DESCRIPTION
This avoids window when database is closed and any thread attempting to use it
will crash immediately

Second change it simply reopens database with same parameters without going through `openDb`