### PR TITLE
Small improvements in TCP server

### DIFF
--- a/index-server/src/Ergvein/Index/Server/TCPService/Connections.hs
+++ b/index-server/src/Ergvein/Index/Server/TCPService/Connections.hs
@@ -1,41 +1,11 @@
 module Ergvein.Index.Server.TCPService.Connections 
-  ( openConnection
-  , closeConnection
-  , closeAllConnections
-  , newConnection
+  ( newConnection
   ) where
 
-import Control.Concurrent
-import Control.Concurrent.STM
-import Control.Monad.IO.Unlift
 import Data.Maybe
-import Data.Foldable
-import Ergvein.Index.Server.Dependencies
 import Network.Socket
-
-import qualified Data.Map.Strict as Map
-
-openConnection :: HasConnectionsManagement m => ThreadId -> SockAddr -> Socket -> m ()
-openConnection threadId addr sock = do
-  openedConnectionsRef <- openConnections
-  liftIO $ atomically $ modifyTVar openedConnectionsRef $ Map.insert addr (threadId , sock)
 
 newConnection :: SockAddr -> IO (HostName, ServiceName)
 newConnection addr = do
   (maybeHost, maybePort) <- getNameInfo [NI_NUMERICHOST, NI_NUMERICSERV] True True addr
   pure (fromJust maybeHost , fromJust maybePort)
-
-closeSocketAndKillThread :: (ThreadId, Socket) -> IO ()
-closeSocketAndKillThread (connectionThreadId, connectionSocket) = close connectionSocket >> killThread connectionThreadId
-
-closeConnection :: HasConnectionsManagement m => SockAddr -> m ()
-closeConnection addr = do
-  openedConnectionsRef <- openConnections
-  liftIO $ closeSocketAndKillThread =<< (Map.! addr) <$> readTVarIO openedConnectionsRef
-
-closeAllConnections :: HasConnectionsManagement m => m ()
-closeAllConnections = do
-  openedConnectionsRef <- openConnections
-  liftIO $ do
-    traverse_ closeSocketAndKillThread =<< Map.elems <$> readTVarIO openedConnectionsRef
-    atomically $ writeTVar openedConnectionsRef mempty

--- a/index-server/src/Ergvein/Index/Server/TCPService/MessageHandler.hs
+++ b/index-server/src/Ergvein/Index/Server/TCPService/MessageHandler.hs
@@ -20,7 +20,6 @@ import Ergvein.Index.Server.Metrics
 import Ergvein.Index.Server.Monad
 import Ergvein.Index.Server.PeerDiscovery.Discovery
 import Ergvein.Index.Server.PeerDiscovery.Types
-import Ergvein.Index.Server.TCPService.Connections
 import Ergvein.Index.Server.TCPService.Conversions
 import Ergvein.Text
 import Ergvein.Types.Currency
@@ -80,10 +79,10 @@ handleMsg address (MFiltersEvent FilterEvent {..}) = do
   currency <- currencyCodeToCurrency filterEventCurrency
   slice <- getBlockMetaSlice currency filterEventHeight 1
   let filters = blockFilterFilter . convert <$> slice
-  when (any (/= filterEventBlockFilter) filters) $ do
-   closeConnection address
-   deletePeerBySockAddr $ convert address
-  pure (mempty, False)
+  case any (/= filterEventBlockFilter) filters of
+    True  -> do deletePeerBySockAddr $ convert address
+                pure ([], True)
+    False -> do pure ([], False)
 
 handleMsg _ (MFeeRequest curs) = do
   fees <- liftIO . readTVarIO =<< asks envFeeEstimates

--- a/index-server/src/Ergvein/Index/Server/TCPService/MessageHandler.hs
+++ b/index-server/src/Ergvein/Index/Server/TCPService/MessageHandler.hs
@@ -1,4 +1,6 @@
-module Ergvein.Index.Server.TCPService.MessageHandler where
+module Ergvein.Index.Server.TCPService.MessageHandler
+  ( handleMsg
+  ) where
 
 import Control.Concurrent.STM
 import Control.Monad.IO.Class

--- a/index-server/src/Ergvein/Index/Server/TCPService/Server.hs
+++ b/index-server/src/Ergvein/Index/Server/TCPService/Server.hs
@@ -90,15 +90,11 @@ runConnection (sock, addr) = incGaugeWhile activeConnsGauge $ do
       listenLoop sendChan
     Left err -> do
       logErrorN $ "<" <> showt addr <> ">: Rejecting client on handshake phase with: " <> showt err
-      liftIO $ do
-        rawSendMsg $ MReject err
-        threadDelay 100000
+      liftIO $ rawSendMsg $ MReject err
       closeConnection addr
     Right (MReject r : _, _) -> do
       logErrorN $ "<" <> showt addr <> ">: Rejecting client on handshake phase with: " <> showt r
-      liftIO $ do
-        rawSendMsg $ MReject r
-        threadDelay 100000
+      liftIO $ rawSendMsg $ MReject r
       closeConnection addr
     Right msg -> do
       logErrorN $ "<" <> showt addr <> ">: Impossible! Tried to send something that is not MVersionACK or MReject to client at handshake: " <> showt msg
@@ -129,7 +125,6 @@ runConnection (sock, addr) = incGaugeWhile activeConnsGauge $ do
               liftIO $ forM_ msgs $ writeMsg destinationChan
               if closeIt then do
                 logInfoN $ "<" <> showt addr <> ">: Closing connection on our side"
-                liftIO $ threadDelay 100000
                 closeConnection addr
               else listenLoop'
             Left Reject {..} | rejectMsgCode == ZeroBytesReceived -> do
@@ -139,7 +134,6 @@ runConnection (sock, addr) = incGaugeWhile activeConnsGauge $ do
               logErrorN $ "<" <> showt addr <> ">: Rejecting client with: " <> showt err
               liftIO $ do
                 writeMsg destinationChan $ MReject err
-                threadDelay 100000
               closeConnection addr
 
 

--- a/index-server/src/Ergvein/Index/Server/TCPService/Server.hs
+++ b/index-server/src/Ergvein/Index/Server/TCPService/Server.hs
@@ -34,15 +34,6 @@ import Ergvein.Index.Server.TCPService.Connections
 import qualified Data.ByteString as BS
 import qualified Network.Socket.ByteString as NS
 
--- Pinger thread
-runPinger :: ServerM Thread
-runPinger = create $ const $ logOnException "runPinger" $ do
-  broadChan <- liftIO . atomically . dupTChan =<< broadcastChannel
-  forever $ liftIO $ do
-    threadDelay 5000000
-    msg <- MPing <$> randomIO
-    atomically $ writeTChan broadChan msg
-
 runTcpSrv :: ServerM Thread
 runTcpSrv = create $ logOnException "runTcpSrv" . tcpSrv
 

--- a/index-server/src/Ergvein/Index/Server/TCPService/Socket.hs
+++ b/index-server/src/Ergvein/Index/Server/TCPService/Socket.hs
@@ -1,5 +1,6 @@
 module Ergvein.Index.Server.TCPService.Socket where
 
+import Control.Applicative
 import Control.Concurrent.STM
 import Control.Monad
 import Control.Monad.IO.Unlift
@@ -90,10 +91,10 @@ receiveExactly intVar sock n = go n mempty
 readAllTVar :: TChan a -> STM [a]
 readAllTVar chan = go []
   where
-    go !acc = do
-      a <- readTChan chan
-      empty <- isEmptyTChan chan
-      if empty then pure (a : acc) else go (a : acc)
+    go !acc = do a <- readTChan chan
+                 go (a : acc)
+           <|> pure acc
+
 
 -- * Note
 -- We need to copy some functions from network-simple due problems with

--- a/index-server/src/Ergvein/Index/Server/TCPService/Socket.hs
+++ b/index-server/src/Ergvein/Index/Server/TCPService/Socket.hs
@@ -88,10 +88,10 @@ receiveExactly intVar sock n = go n mempty
           acc' = acc <> BB.byteString bs
           in if l < i then go (i - l) acc' else pure . BSL.toStrict . BB.toLazyByteString $ acc'
 
-readAllTVar :: TChan a -> STM [a]
-readAllTVar chan = go []
+readAllTVar :: STM a -> STM [a]
+readAllTVar readValue = go []
   where
-    go !acc = do a <- readTChan chan
+    go !acc = do a <- readValue
                  go (a : acc)
            <|> pure acc
 

--- a/index-server/src/Ergvein/Index/Server/TCPService/Socket.hs
+++ b/index-server/src/Ergvein/Index/Server/TCPService/Socket.hs
@@ -1,6 +1,5 @@
 module Ergvein.Index.Server.TCPService.Socket where
 
-import Control.Applicative
 import Control.Concurrent.STM
 import Control.Monad
 import Control.Monad.IO.Unlift
@@ -87,13 +86,6 @@ receiveExactly intVar sock n = go n mempty
           l = BS.length bs
           acc' = acc <> BB.byteString bs
           in if l < i then go (i - l) acc' else pure . BSL.toStrict . BB.toLazyByteString $ acc'
-
-readAllTVar :: STM a -> STM [a]
-readAllTVar readValue = go []
-  where
-    go !acc = do a <- readValue
-                 go (a : acc)
-           <|> pure acc
 
 
 -- * Note


### PR DESCRIPTION
This PR doesn't fix memory leaks maybe somewhat reduces leak rate.

1. Drop broadcast loop. STM has retry so we can read from both channels at once. I think this should reduce rate of leaks somewhat. Broadcast loop will write to unbounded channel every broadcast message it receives. 
2. Close connection in the main loop instead of handler of MFiltersEvent
3. Drop registerConnection and perform registration in the body of runConnection.It doesn;t win us much but allows to tie resource management to lifetime of main thread of client handler
4. Instead of polling shutdownFlag block on it

P.S. Not tested since I'm not sure how to test this