### PR TITLE
Don't leak thread in Ergvein.Index.Server.TCPService.BTC

### DIFF
--- a/index-server/ergvein-index-server.cabal
+++ b/index-server/ergvein-index-server.cabal
@@ -40,6 +40,7 @@ library
     Ergvein.Index.Server.PeerDiscovery.Types
     Ergvein.Index.Server.TCPService.BTC
     Ergvein.Index.Server.TCPService.Connections
+    Ergvein.Index.Server.TCPService.Supervisor
     Ergvein.Index.Server.TCPService.Conversions
     Ergvein.Index.Server.TCPService.MessageHandler
     Ergvein.Index.Server.TCPService.Server

--- a/index-server/src/Ergvein/Index/Server/TCPService/BTC.hs
+++ b/index-server/src/Ergvein/Index/Server/TCPService/BTC.hs
@@ -92,11 +92,9 @@ connectBtc net host port closeVar restartChan = do
   let readErFire = atomically . writeTChan actChan . BTCSockFail
   let inFire = atomically . writeTChan incChan
 
-  void $ fork $ liftIO $ fix $ \next -> do
-    b <- atomically $ readTVar closeVar
-    if b
-      then atomically $ writeTChan actChan BTCSockClose
-      else threadDelay 1000000 >> next
+  void $ fork $ liftIO $ atomically $ do
+    check =<< readTVar closeVar
+    writeTChan actChan BTCSockClose
 
   void $ fork $ liftIO $ fix $ \next -> do
     atomically $ do

--- a/index-server/src/Ergvein/Index/Server/TCPService/BTC.hs
+++ b/index-server/src/Ergvein/Index/Server/TCPService/BTC.hs
@@ -8,9 +8,9 @@ module Ergvein.Index.Server.TCPService.BTC
   ) where
 
 import Control.Applicative
-import Control.Concurrent.Lifted (fork, threadDelay)
+import Control.Concurrent        (forkIO,threadDelay)
 import Control.Concurrent.STM
-import Control.Monad.Catch (throwM, MonadThrow)
+import Control.Monad.Catch       (throwM, MonadThrow)
 import Control.Monad.IO.Unlift
 import Control.Monad.Random (randomIO)
 import Control.Monad.Reader
@@ -94,7 +94,7 @@ connectBtc net host port closeVar restartChan = do
   let readErFire = atomically . writeTChan actChan . BTCSockFail
   let inFire = atomically . writeTChan incChan
 
-  void $ fork $ liftIO $ fix $ \next -> do
+  void $ liftIO $ forkIO $ fix $ \next -> do
     continue <- connect host port $ \(sock, _sockaddr) -> do
       withWorkersUnion $ \wrkUnion -> do
         atomically $ writeTVar shakeVar False

--- a/index-server/src/Ergvein/Index/Server/TCPService/Server.hs
+++ b/index-server/src/Ergvein/Index/Server/TCPService/Server.hs
@@ -2,14 +2,9 @@
 module Ergvein.Index.Server.TCPService.Server where
 
 import Control.Applicative
-import Control.Concurrent
-import Control.Concurrent.Async.Lifted (Async,async)
 import Control.Concurrent.STM
 import Control.Immortal                (Thread,create,stop)
-import Control.Exception               (AsyncException(..),throwIO)
 import Control.Monad
-import Control.Monad.Base
-import Control.Monad.Trans.Control
 import Control.Monad.Catch
 import Control.Monad.IO.Unlift
 import Control.Monad.Logger
@@ -19,7 +14,6 @@ import qualified Control.Concurrent.Async as Async
 import Data.Attoparsec.ByteString
 import Data.ByteString.Builder
 import Data.Either.Combinators
-import Data.Set (Set)
 import Data.Word
 import Network.Socket
 
@@ -34,77 +28,10 @@ import Ergvein.Index.Server.Metrics
 import Ergvein.Index.Server.Monad
 import Ergvein.Index.Server.TCPService.MessageHandler
 import Ergvein.Index.Server.TCPService.Socket as S
+import Ergvein.Index.Server.TCPService.Supervisor
 
 import qualified Data.ByteString as BS
-import qualified Data.Set        as Set
 import qualified Network.Socket.ByteString as NS
-
-
-----------------------------------------------------------------
--- Async stuff
-----------------------------------------------------------------
-
--- | Unhandled exception in child thread.
-data ExceptionInLinkedThread = ExceptionInLinkedThread SomeException
-  deriving Show
-instance Exception ExceptionInLinkedThread
-
--- | Create worker thread
-withLinkedWorker
-  :: (MonadBaseControl IO m)
-  => m a -> (Async () -> m b) -> m b
-withLinkedWorker action cont = restoreM =<< do
-  -- FIXME: test that we correctly deal with blocking calls with
-  --        throwTo. async use uninterruptibleCancel for example.
-  liftBaseWith $ \runInIO -> do
-    tid <- myThreadId
-    mask $ \restore -> do
-      -- Here we spawn worker thread which will throw unhandled exception to main thread.
-      a <- Async.async $ restore (runInIO action) `catch` \e -> do
-        unless (ignoreException e) $ throwTo tid (ExceptionInLinkedThread e)
-        throwIO e
-      restore (runInIO (cont (() <$ a))) `finally` Async.cancel a
-
--- | Same as 'withLinkedWorker' for use in cases when
-withLinkedWorker_ :: (MonadBaseControl IO m) => m a -> m b -> m b
-withLinkedWorker_ action = withLinkedWorker action . const
-
--- Exception to ignore for linked threads
-ignoreException :: SomeException -> Bool
-ignoreException e
-  | Just Async.AsyncCancelled <- fromException e = True
-  | Just ThreadKilled         <- fromException e = True
-  | otherwise = False
-
-
--- | Set of worker threads
-newtype WorkersUnion = WorkersUnion (TVar (Set ThreadId))
-
--- | Create handler for set of worker threads which all will be
--- limited once 'withWorkersUnion' terminates.
-withWorkersUnion
-  :: (MonadIO m, MonadMask m)
-  => (WorkersUnion -> m a) -> m a
-withWorkersUnion = bracket ini fini
-  where
-    ini  = WorkersUnion <$> liftIO (newTVarIO mempty)
-    fini (WorkersUnion tidsVar) = liftIO $ do
-      tids <- readTVarIO tidsVar
-      forM_ tids $ \tid -> forkIO $ throwTo tid Async.AsyncCancelled
-
--- | Spawn worker thread which will be terminated when
--- 'withWorkersUnion' exits.
-spawnWorker
-  :: (MonadBaseControl IO m, MonadMask m)
-  => WorkersUnion -> m a -> m ()
-spawnWorker (WorkersUnion tidsVar) action = do
-  mask_ $ do
-    a <- async action
-    liftBase $ atomically $ modifyTVar' tidsVar $ Set.insert (Async.asyncThreadId a)
-
-----------------------------------------------------------------
--- Server
-----------------------------------------------------------------
 
 
 runTcpSrv :: ServerM Thread

--- a/index-server/src/Ergvein/Index/Server/TCPService/Supervisor.hs
+++ b/index-server/src/Ergvein/Index/Server/TCPService/Supervisor.hs
@@ -1,0 +1,82 @@
+-- |
+module Ergvein.Index.Server.TCPService.Supervisor
+  ( -- * Linked worker threads
+    withLinkedWorker
+  , withLinkedWorker_
+  , ExceptionInLinkedThread(..)
+    -- * Worker unions
+  , WorkersUnion
+  , withWorkersUnion
+  , spawnWorker
+  ) where
+
+import Control.Concurrent              (ThreadId,myThreadId,forkIO)
+import Control.Concurrent.STM
+import Control.Concurrent.Async.Lifted (Async,async)
+import qualified Control.Concurrent.Async as Async
+import Control.Exception               (Exception,AsyncException(..),throwIO,throwTo)
+import Control.Monad
+import Control.Monad.Base
+import Control.Monad.Catch
+import Control.Monad.Trans.Control
+import Control.Monad.IO.Unlift
+import qualified Data.Set        as Set
+
+
+-- | Unhandled exception in child thread.
+data ExceptionInLinkedThread = ExceptionInLinkedThread SomeException
+  deriving Show
+instance Exception ExceptionInLinkedThread
+
+-- | Create worker thread
+withLinkedWorker
+  :: (MonadBaseControl IO m)
+  => m a -> (Async () -> m b) -> m b
+withLinkedWorker action cont = restoreM =<< do
+  -- FIXME: test that we correctly deal with blocking calls with
+  --        throwTo. async use uninterruptibleCancel for example.
+  liftBaseWith $ \runInIO -> do
+    tid <- myThreadId
+    mask $ \restore -> do
+      -- Here we spawn worker thread which will throw unhandled exception to main thread.
+      a <- Async.async $ restore (runInIO action) `catch` \e -> do
+        unless (ignoreException e) $ throwTo tid (ExceptionInLinkedThread e)
+        throwIO e
+      restore (runInIO (cont (() <$ a))) `finally` Async.cancel a
+
+-- | Same as 'withLinkedWorker' for use in cases when
+withLinkedWorker_ :: (MonadBaseControl IO m) => m a -> m b -> m b
+withLinkedWorker_ action = withLinkedWorker action . const
+
+-- Exception to ignore for linked threads
+ignoreException :: SomeException -> Bool
+ignoreException e
+  | Just Async.AsyncCancelled <- fromException e = True
+  | Just ThreadKilled         <- fromException e = True
+  | otherwise = False
+
+
+-- | Set of worker threads
+newtype WorkersUnion = WorkersUnion (TVar (Set.Set ThreadId))
+
+-- | Create handler for set of worker threads which all will be
+-- limited once 'withWorkersUnion' terminates.
+withWorkersUnion
+  :: (MonadIO m, MonadMask m)
+  => (WorkersUnion -> m a) -> m a
+withWorkersUnion = bracket ini fini
+  where
+    ini  = WorkersUnion <$> liftIO (newTVarIO mempty)
+    fini (WorkersUnion tidsVar) = liftIO $ do
+      tids <- readTVarIO tidsVar
+      forM_ tids $ \tid -> forkIO $ throwTo tid Async.AsyncCancelled
+
+-- | Spawn worker thread which will be terminated when
+-- 'withWorkersUnion' exits.
+spawnWorker
+  :: (MonadBaseControl IO m, MonadMask m)
+  => WorkersUnion -> m a -> m ()
+spawnWorker (WorkersUnion tidsVar) action = do
+  mask_ $ do
+    a <- async action
+    liftBase $ atomically $ modifyTVar' tidsVar $ Set.insert (Async.asyncThreadId a)


### PR DESCRIPTION
General idea is same as in #885. Drop few threads and rely on `<|>` for STM to read from several sources. Then make sure that all worker threads are properly terminated by using supervisor. 

I'm not sure that it's proper way to test this code but indexer happily (but slowly) syncs after being offline for a few days and survive restart of bitcoin node just fine