### PR TITLE
Fix space leak in spawnWorker

### DIFF
--- a/index-server/src/Ergvein/Index/Server/TCPService/Supervisor.hs
+++ b/index-server/src/Ergvein/Index/Server/TCPService/Supervisor.hs
@@ -78,5 +78,7 @@ spawnWorker
   => WorkersUnion -> m a -> m ()
 spawnWorker (WorkersUnion tidsVar) action = do
   mask_ $ do
-    a <- async action
+    a <- async $ action `finally` do
+      liftBase (do tid <- myThreadId
+                   atomically $ modifyTVar' tidsVar $ Set.delete tid)
     liftBase $ atomically $ modifyTVar' tidsVar $ Set.insert (Async.asyncThreadId a)


### PR DESCRIPTION
We didn't removed ThreadId on thread death