### PR TITLE
Use GND to derive MonadBaseControl & MonadUnlistIO instances

### DIFF
--- a/index-server/ergvein-index-server.cabal
+++ b/index-server/ergvein-index-server.cabal
@@ -103,6 +103,7 @@ library
       , safe                     >= 0.3     &&  < 0.4
       , safe-exceptions
       , stm                      >= 2.5     &&  < 2.6
+      , split                    >= 0.2.3
       , template-haskell         >= 2.14    &&  < 2.15
       , text                     >= 1.2     &&  < 1.3
       , time                     >= 1.8     &&  < 1.9

--- a/index-server/src/Ergvein/Index/Server/DB/Queries.hs
+++ b/index-server/src/Ergvein/Index/Server/DB/Queries.hs
@@ -34,6 +34,7 @@ import Conversion
 import Data.ByteString.Short (ShortByteString)
 import Data.Default
 import Data.Foldable
+import Data.List.Split (chunksOf)
 import Data.Word
 import Data.Maybe
 import Data.Time.Clock
@@ -50,7 +51,6 @@ import Ergvein.Index.Server.DB.Utils
 import Ergvein.Index.Server.DB.Wrapper
 import Ergvein.Index.Server.Dependencies
 import Ergvein.Index.Server.PeerDiscovery.Types
-import Ergvein.Index.Server.Utils
 import Ergvein.Types.Currency as Currency
 import Ergvein.Types.Transaction
 
@@ -194,7 +194,7 @@ loadRollbackSequence cur = do
 insertSpentTxUpdates :: (HasUtxoDB m, MonadLogger m, MonadBaseControl IO m) => Currency -> Map.Map TxHash Word32 -> m ()
 insertSpentTxUpdates _ outs = do
   udb <- getUtxoDb
-  let outsl = mkChunks 100 $ Map.toList outs
+  let outsl = chunksOf 100 $ Map.toList outs
   upds <- fmap (mconcat . mconcat) $ mapConcurrently (traverse (mkupds udb)) outsl
   writeLDB udb def upds
   where

--- a/index-server/src/Ergvein/Index/Server/TCPService/Supervisor.hs
+++ b/index-server/src/Ergvein/Index/Server/TCPService/Supervisor.hs
@@ -77,8 +77,8 @@ spawnWorker
   :: (MonadBaseControl IO m, MonadMask m)
   => WorkersUnion -> m a -> m ()
 spawnWorker (WorkersUnion tidsVar) action = do
-  mask_ $ do
-    a <- async $ action `finally` do
+  mask $ \unmask -> do
+    a <- async $ unmask action `finally` do
       liftBase (do tid <- myThreadId
                    atomically $ modifyTVar' tidsVar $ Set.delete tid)
     liftBase $ atomically $ modifyTVar' tidsVar $ Set.insert (Async.asyncThreadId a)

--- a/index-server/src/Ergvein/Index/Server/TxIndex/Monad.hs
+++ b/index-server/src/Ergvein/Index/Server/TxIndex/Monad.hs
@@ -52,10 +52,10 @@ data TxIndexEnv = TxIndexEnv
     }
 
 newtype TxIndexM a = TxIndexM { unTxIndexM :: ReaderT TxIndexEnv (LoggingT IO) a }
-  deriving ( Functor, Applicative, Monad, MonadIO, MonadLogger
-           , MonadReader TxIndexEnv
-           , MonadThrow, MonadCatch, MonadMask
-           , MonadBase IO, MonadBaseControl IO)
+  deriving newtype ( Functor, Applicative, Monad, MonadIO, MonadLogger
+                   , MonadReader TxIndexEnv
+                   , MonadThrow, MonadCatch, MonadMask
+                   , MonadBase IO, MonadBaseControl IO, MonadUnliftIO)
   -- To avoid orphan we unwrap LoggingT as its reader representation
   deriving MonadMonitor via (ReaderT TxIndexEnv (ReaderT (Loc -> LogSource -> LogLevel -> LogStr -> IO ()) IO))
 
@@ -92,10 +92,6 @@ instance BitcoinApiMonad TxIndexM where
 instance HasShutdownFlag TxIndexM where
   getShutdownFlag = asks envShutdownFlag
   {-# INLINE getShutdownFlag #-}
-
-instance MonadUnliftIO TxIndexM where
-  askUnliftIO = TxIndexM $ (\(UnliftIO run) -> UnliftIO $ run . unTxIndexM) <$> askUnliftIO
-  withRunInIO go = TxIndexM $ withRunInIO (\k -> go $ k . unTxIndexM)
 
 withTxIndexEnv :: (MonadIO m, MonadLogger m, MonadMask m, MonadBaseControl IO m, MonadMask m)
   => Bool               -- ^ flag, def True: wait for node connections to be up before finalizing the env

--- a/index-server/src/Ergvein/Index/Server/Utils.hs
+++ b/index-server/src/Ergvein/Index/Server/Utils.hs
@@ -24,10 +24,3 @@ uniqueWithCount = Map.toList . L.foldl' (\m a -> Map.insertWith (+) a 1 m) Map.e
 
 cancelableDelay :: TVar Bool -> Int -> IO ()
 cancelableDelay cancellationToken delay = void $ timeout delay $ atomically $ readTVar cancellationToken >>= (`unless` retry)
-
-mkChunks :: Int -> [a] -> [[a]]
-mkChunks n vals = mkChunks' [] vals
-  where
-     mkChunks' acc xs = case xs of
-       [] -> acc
-       _ -> let (a,b) = splitAt n xs in mkChunks' (acc ++ [a]) b


### PR DESCRIPTION
Also use split library for chunking lists. It's transitive dependency anyway