### PR TITLE
Avoid building executable on ARM platform

### DIFF
--- a/ergo-protocol-client/ergo-protocol-client.cabal
+++ b/ergo-protocol-client/ergo-protocol-client.cabal
@@ -12,6 +12,12 @@ author:              Anton Gushcha, Aminion, Vladimir Krutkin, Levon Oganyan, Se
 maintainer:          Anton Gushcha <ncrashed@protonmail.com>
 extra-source-files:  CHANGELOG.md
 
+flag client-tool
+  description: Build executable for connecting to Ergo node
+  -- See #968, don't build on ARM to prevent linker errors
+  default: False
+  manual: True
+
 library
   hs-source-dirs:      src
   exposed-modules:
@@ -40,6 +46,10 @@ library
     TemplateHaskell
 
 executable ergo-protocol-client
+  if flag(client-tool)
+    buildable: True
+  else
+    buildable: False
   hs-source-dirs:      app
   main-is:             Main.hs
   ghc-options:         -threaded -O3

--- a/wallet/ergvein-wallet.cabal
+++ b/wallet/ergvein-wallet.cabal
@@ -115,6 +115,7 @@ library
         , directory
         , dns                     >= 4.0        && < 5.0
         , ergo-protocol
+        , ergo-protocol-client
         , ergvein-common          >= 1.0        && < 1.1
         , ergvein-core
         , ergvein-crypto          >= 0.1        && < 0.2


### PR DESCRIPTION
Fix #968. We can avoid linker errors by simply not building unused tooling on ARM targets.