### PR TITLE
I1049 custom nodes

### DIFF
--- a/ergvein-core/app/Main.hs
+++ b/ergvein-core/app/Main.hs
@@ -83,7 +83,8 @@ main = do
     test :: MonadSettings t m => SockAddr -> m (NodeBtc t)
     test addr = do
       (msgE, msgFire) <- newTriggerEvent
-      btcNode <- initBtcNode True (fromIntegral 100) addr msgE
+      let btcRating = 100 -- Initial rating for the node. 100 is a perfect node
+      btcNode <- initBtcNode True btcRating addr msgE
 
       --handshake
       handshakeE <- delay 0.5 . ffilter id . updated . nodeconIsUp $ btcNode

--- a/ergvein-core/app/Main.hs
+++ b/ergvein-core/app/Main.hs
@@ -83,8 +83,8 @@ main = do
     test :: MonadSettings t m => SockAddr -> m (NodeBtc t)
     test addr = do
       (msgE, msgFire) <- newTriggerEvent
-      let btcRating = 100 -- Initial rating for the node. 100 is a perfect node
-      btcNode <- initBtcNode True btcRating addr msgE
+      let initRating = 100 -- Initial rating for the node. 100 is a perfect node
+      btcNode <- initBtcNode True initRating addr msgE
 
       --handshake
       handshakeE <- delay 0.5 . ffilter id . updated . nodeconIsUp $ btcNode

--- a/ergvein-core/src/Ergvein/Core/Node/Btc.hs
+++ b/ergvein-core/src/Ergvein/Core/Node/Btc.hs
@@ -54,8 +54,9 @@ initBtcNode :: (MonadSettings t m)
   -> NodeRating           -- ^ Initial rating for the node
   -> SockAddr             -- ^ Node address
   -> Event t NodeMessage  -- ^ Incoming messages for the node, including send requests
+  -> Bool                 -- ^ Is the node private
   -> m (NodeBtc t)
-initBtcNode doLog rating sa msgE = do
+initBtcNode doLog rating sa msgE isPrivate = do
 
   let net = btcNetwork
       nodeLog :: MonadIO m => Text -> m ()
@@ -153,6 +154,7 @@ initBtcNode doLog rating sa msgE = do
   , nodeconDoLog      = doLog
   , nodeconHeight     = heightD
   , nodeconRating     = rateRef
+  , nodeconIsPrivate  = isPrivate
   }
 
 -- | Internal peeker to parse messages coming from peer.

--- a/ergvein-core/src/Ergvein/Core/Node/Monad.hs
+++ b/ergvein-core/src/Ergvein/Core/Node/Monad.hs
@@ -14,6 +14,7 @@ module Ergvein.Core.Node.Monad(
   , requestBroadcast
   , sendRandomNode
   , getNodeHeightBtc
+  , clearNodeConns
   ) where
 
 import Control.Monad.IO.Class
@@ -151,3 +152,8 @@ getNodeHeightBtc = do
   let heightD = join $ ffor conMapD $ \connMap ->
         L.foldl' (\d1 d2 -> ffor2 d1 d2 max) (pure Nothing) (nodeconHeight <$> M.elems connMap)
   holdUniqDyn heightD
+
+clearNodeConns :: MonadNode t m => Event t () -> m (Event t ())
+clearNodeConns clearE = do
+  ref <- getNodeConnRef
+  performEvent $ ffor clearE $ const $ writeExternalRef ref mempty

--- a/ergvein-core/src/Ergvein/Core/Node/Types.hs
+++ b/ergvein-core/src/Ergvein/Core/Node/Types.hs
@@ -122,7 +122,7 @@ getAllConnByCurrency :: Currency -> ConnMap t -> Maybe (Map SockAddr (NodeConn t
 getAllConnByCurrency cur cm = case cur of
   BTC  -> fmap NodeConnBtc <$> DM.lookup BtcTag cm
 
-data NodeRating = NodeRating {unNodeRating :: Word8}
+newtype NodeRating = NodeRating {unNodeRating :: Word8}
   deriving (Eq, Ord, Show)
 
 -- | Node rating is capped at 100

--- a/ergvein-core/src/Ergvein/Core/Node/Types.hs
+++ b/ergvein-core/src/Ergvein/Core/Node/Types.hs
@@ -67,6 +67,7 @@ data NodeConnection t cur = NodeConnection {
 , nodeconDoLog      :: !Bool
 , nodeconHeight     :: !(Dynamic t (Maybe Word32))
 , nodeconRating     :: !(ExternalRef t NodeRating)
+, nodeconIsPrivate  :: !Bool
 }
 
 data NodeStatus = NodeStatus {

--- a/ergvein-core/src/Ergvein/Core/Store/Monad.hs
+++ b/ergvein-core/src/Ergvein/Core/Store/Monad.hs
@@ -39,6 +39,8 @@ module Ergvein.Core.Store.Monad(
   , getUnconfirmedTxs
   , setSeedBackupRequired
   , setRestoreStartHeightE
+  , clearCustomNode
+  , setCustomNode
   ) where
 
 import Control.Concurrent.MVar
@@ -419,6 +421,14 @@ getCustomNodeD = do
   holdUniqDyn $ ffor pubStorageD $ \ps -> let
     PubStorageBtc bs = ps ^. btcPubStorage . currencyPubStorage'meta
     in bs ^. btcPubStorage'customNode
+
+clearCustomNode :: MonadStorage t m => Event t () -> m (Event t ())
+clearCustomNode clearE = modifyPubStorage "clearCustomNode" $ ffor clearE $ \_ ps ->
+  Just $ modifyCurrStorageBtc (btcPubStorage'customNode .~ Nothing) ps
+
+setCustomNode :: MonadStorage t m => Event t Text -> m (Event t ())
+setCustomNode setE = modifyPubStorage "setCustomNode" $ ffor setE $ \n ps ->
+  Just $ modifyCurrStorageBtc (btcPubStorage'customNode .~ Just n) ps
 
 isCustomModeD :: (MonadStorage t m, MonadFix m) => m (Dynamic t Bool)
 isCustomModeD = holdUniqDyn . fmap isJust =<< getCustomNodeD

--- a/ergvein-core/src/Ergvein/Core/Store/Monad.hs
+++ b/ergvein-core/src/Ergvein/Core/Store/Monad.hs
@@ -33,6 +33,8 @@ module Ergvein.Core.Store.Monad(
   , getScannedHeight
   , addSuperbBtcNode
   , removeSuperbBtcNode
+  , getCustomNodeD
+  , isCustomModeD
   , getConfirmedTxs
   , getUnconfirmedTxs
   , setSeedBackupRequired
@@ -410,6 +412,16 @@ addSuperbBtcNode saE = modifyPubStorage "addSuperbBtcNode" $ ffor saE $ \sa ps -
 removeSuperbBtcNode :: MonadStorage t m => Event t SockAddr -> m (Event t ())
 removeSuperbBtcNode saE = modifyPubStorage "removeSuperbBtcNode" $ ffor saE $ \sa ps ->
   Just $ modifyCurrStorageBtc (btcPubStorage'preferredNodes %~ S.delete (showt sa)) ps
+
+getCustomNodeD :: (MonadStorage t m, MonadFix m) => m (Dynamic t (Maybe Text))
+getCustomNodeD = do
+  pubStorageD <- getPubStorageD
+  holdUniqDyn $ ffor pubStorageD $ \ps -> let
+    PubStorageBtc bs = ps ^. btcPubStorage . currencyPubStorage'meta
+    in bs ^. btcPubStorage'customNode
+
+isCustomModeD :: (MonadStorage t m, MonadFix m) => m (Dynamic t Bool)
+isCustomModeD = holdUniqDyn . fmap isJust =<< getCustomNodeD
 
 -- ===========================================================================
 --           HasPubStorage helpers

--- a/ergvein-core/src/Ergvein/Core/Store/WalletInfo.hs
+++ b/ergvein-core/src/Ergvein/Core/Store/WalletInfo.hs
@@ -19,6 +19,7 @@ import Reflex.Localize
 import Reflex.Localize.Language
 import Sepulcas.Native
 
+import Data.Text (Text)
 import qualified Data.Text as T
 
 data WalletInfoAlert = CreateStorageAlert !StorageAlert | GenerateECIESKeyAlert | LoadStorageAlert !StorageAlert
@@ -35,11 +36,12 @@ initWalletInfo :: (MonadIO m, PlatformNatives, HasStoreDir m, LocalizedPrint Sto
   -> Password
   -> BlockHeight
   -> Bool
+  -> Maybe Text
   -> m (Either WalletInfoAlert WalletInfo)
-initWalletInfo lang wt seedBackupRequired mpath mnemonic curs login pass startingHeight isPass = do
+initWalletInfo lang wt seedBackupRequired mpath mnemonic curs login pass startingHeight isPass mnode = do
   let fname = "meta_wallet_" <> T.replace " " "_" login
   when (isAndroid && isPass) $ storeValue fname True True
-  mstorage <- createStorage (wt == WalletRestored) seedBackupRequired mpath mnemonic (login, pass) startingHeight curs
+  mstorage <- createStorage (wt == WalletRestored) seedBackupRequired mpath mnemonic (login, pass) startingHeight curs mnode
   case mstorage of
     Left err -> do
       logWrite $ localizedShow lang err

--- a/ergvein-core/src/Ergvein/Core/Worker/Node.hs
+++ b/ergvein-core/src/Ergvein/Core/Worker/Node.hs
@@ -298,7 +298,7 @@ urlCacheManager initSocks reqE = mdo
   performEvent_ $ ffor batchE $ \urls -> liftIO $ do
     n <- readTVarIO cntVar
     let (xs,ys) = splitAt (targetNodeNum - n) urls
-    when (not $ null xs) $ do
+    unless (null xs) $ do
       respFire xs
       atomically $ writeTVar cntVar (n + length xs)
     modifyExternalRefMaybe_ urlsRef $ addSocksToCache ys
@@ -324,7 +324,7 @@ urlCacheManager initSocks reqE = mdo
     -- Return event with addrs from responses
     getSecondNodes :: Event t Int -> Int -> [SockAddr] -> Workflow t m (Event t [SockAddr])
     getSecondNodes restartE n urls = Workflow $ do
-      urlsE <- flip mapM urls $ \u -> mdo
+      urlsE <- forM urls $ \u -> mdo
         node <- initBtcNode False 100 u reqE False
         reqE <- eventToNextFrame $ NodeMsgReq (NodeReqBtc MGetAddr) <$ (nodeconOpensE node)
         pure $ fforMaybe (nodeconRespE node) $ \case

--- a/ergvein-core/src/Ergvein/Core/Worker/Node.hs
+++ b/ergvein-core/src/Ergvein/Core/Worker/Node.hs
@@ -72,9 +72,52 @@ btcLog v = logWrite $ "[nodeController][" <> showt BTC <> "]: " <> v
 handleDecDetector :: Int -> (Bool, Int) -> (Bool, Int)
 handleDecDetector n (_, prev) = if n < prev then (True, n) else (False, n)
 
-btcNodeController ::(MonadNode t m, MonadStorage t m, MonadSettings t m
+-- | Track custom node field.
+-- If there is a valid custom node, use a simplified private node controller
+btcNodeController :: (MonadNode t m, MonadStorage t m, MonadSettings t m
   , MonadWallet t m, MonadStatus t m, MonadHasMain m) => m ()
-btcNodeController = mdo
+btcNodeController = do
+  customNodeD <- getCustomNodeD
+  void $ networkHoldDyn $ ffor customNodeD $ \case
+    Nothing -> btcPublicNodeController
+    Just url -> do
+      let port = if isTestnet then 18333 else 8333
+      resolver <- mkResolvSeed
+      namedUrl <- resolveAddr resolver port url
+      case namedUrl of
+        Nothing -> btcPublicNodeController
+        Just (NamedSockAddr _ sa) -> btcPrivateNodeController sa
+
+btcPrivateNodeController :: (MonadNode t m, MonadStorage t m, MonadSettings t m
+  , MonadWallet t m, MonadStatus t m, MonadHasMain m) => SockAddr -> m ()
+btcPrivateNodeController sa = do
+  btcLog "Starting private"
+  sel         <- getNodeNodeReqSelector
+  conMapD     <- getNodeConnectionsD
+  nodeRef     <- getNodeConnRef
+  pubStorageD <- getPubStorageD
+  let txidsD  = ffor pubStorageD $ \ps -> M.keysSet $ ps ^. btcPubStorage . currencyPubStorage'transactions
+  let reqE = extractReq sel BTC sa
+  node <- initBtcNode True 100 sa reqE True
+  modifyExternalRef nodeRef $ \cm -> (addNodeConn (NodeConnBtc node) cm, ())
+  let respE = nodeconRespE node
+  let txInvsE = flip push respE $ \case
+        MInv inv -> do
+          txids <- sampleDyn txidsD
+          pure $ filterTxInvs txids inv
+        _ -> pure Nothing
+      reqTxE = (sa,) . NodeReqBtc . MGetData . GetData <$> txInvsE
+  _ <- requestFromNode reqTxE
+  let newTxE = fforMaybe respE $ \case
+        MTx tx -> Just tx
+        _ -> Nothing
+  myTxSender sa respE
+  void $ btcMempoolTxInserter newTxE
+
+
+btcPublicNodeController :: (MonadNode t m, MonadStorage t m, MonadSettings t m
+  , MonadWallet t m, MonadStatus t m, MonadHasMain m) => m ()
+btcPublicNodeController = mdo
   btcLog "Starting"
   sel         <- getNodeNodeReqSelector
   conMapD     <- getNodeConnectionsD
@@ -101,7 +144,7 @@ btcNodeController = mdo
   tmpD <- listWithKeyShallowDiff M.empty listActionE $ \u _ _ -> do
     let reqE = extractReq sel BTC u
     let initRating = if u `elem` initSocks then 100 else 50
-    node <- initBtcNode True initRating u reqE
+    node <- initBtcNode True initRating u reqE False
     modifyExternalRef nodeRef $ \cm -> (addNodeConn (NodeConnBtc node) cm, ())
     killE <- delay 0.1 $ nodeconCloseE node
     timeoutE <- delay handshakeTimeout =<< getPostBuild
@@ -279,7 +322,7 @@ urlCacheManager initSocks reqE = mdo
     getSecondNodes :: Event t Int -> Int -> [SockAddr] -> Workflow t m (Event t [SockAddr])
     getSecondNodes restartE n urls = Workflow $ do
       urlsE <- flip mapM urls $ \u -> mdo
-        node <- initBtcNode False 100 u reqE
+        node <- initBtcNode False 100 u reqE False
         reqE <- eventToNextFrame $ NodeMsgReq (NodeReqBtc MGetAddr) <$ (nodeconOpensE node)
         pure $ fforMaybe (nodeconRespE node) $ \case
           MAddr (Addr nats) -> let

--- a/ergvein-localize/src/Ergvein/Wallet/Localize/Password.hs
+++ b/ergvein-localize/src/Ergvein/Wallet/Localize/Password.hs
@@ -109,6 +109,16 @@ data PasswordWidgetStrings =
   | PWSInvalidPath
   | PWSMoreOptions
   | PWSLessOptions
+  | PWSCustomNode
+  | PWSCustomNodeDesc
+  | PWSNodeFiller
+  | PWSCheckNode
+  | PWSSaveNode
+  | PWSCancelNode
+  | PWSInvalidIP
+  | PWSNodeOffline
+  | PWSNodeActive Text
+  | PWSNodeSaved Text
 
 instance LocalizedPrint PasswordWidgetStrings where
   localizedShow l v = case l of
@@ -128,6 +138,16 @@ instance LocalizedPrint PasswordWidgetStrings where
       PWSInvalidPath   -> "Derivation path is invalid! Format m/0'/0'/0'"
       PWSMoreOptions   -> "Advanced settings"
       PWSLessOptions   -> "Advanced settings"
+      PWSCustomNode    -> "Private BTC node's IP"
+      PWSCustomNodeDesc -> "You can select a private node to use for all requests"
+      PWSNodeFiller    -> "Enter an IP address"
+      PWSCheckNode     -> "Check"
+      PWSSaveNode      -> "Save"
+      PWSCancelNode    -> "Cancel"
+      PWSInvalidIP     -> "Invalid ip"
+      PWSNodeOffline   -> "Node offline or is not a BTC node"
+      PWSNodeActive t  -> "Node <" <> t <> "> is online! Save it?"
+      PWSNodeSaved  t  -> "Node <" <> t <> "> is saved!"
     Russian -> case v of
       PWSPassword      -> "Пароль"
       PWSPassNamed n   -> "Пароль от " <> n
@@ -144,6 +164,16 @@ instance LocalizedPrint PasswordWidgetStrings where
       PWSInvalidPath   -> "Путь вывода неверен! Формат поля m/0'/0'/0'"
       PWSMoreOptions   -> "Дополнительные настройки"
       PWSLessOptions   -> "Дополнительные настройки"
+      PWSCustomNode    -> "IP адрес частного BTC-узла"
+      PWSCustomNodeDesc -> "Этот узел будет использоваться для всех запросов"
+      PWSNodeFiller    -> "Введите IP адрес"
+      PWSCheckNode     -> "Проверить"
+      PWSSaveNode      -> "Сохранить"
+      PWSCancelNode    -> "Отменить"
+      PWSInvalidIP     -> "Некорректный IP адрес"
+      PWSNodeOffline   -> "Узел оффлайн или не является BTC узлом"
+      PWSNodeActive t  -> "Узел <" <> t <> "> онлайн! Сохранить?"
+      PWSNodeSaved  t  -> "Узел <" <> t <> "> сохранён!"
 
 data ConfirmEmptyPage = CEPBack | CEPSkip | CEPAttention | CEPConsequences
 

--- a/ergvein-localize/src/Ergvein/Wallet/Localize/Settings.hs
+++ b/ergvein-localize/src/Ergvein/Wallet/Localize/Settings.hs
@@ -1,6 +1,7 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Ergvein.Wallet.Localize.Settings(
     SettingsPageStrings(..)
+  , NodeSetupStrings(..)
   , NetSetupStrings(..)
   , DeleteWalletStrings(..)
   ) where
@@ -122,10 +123,10 @@ instance LocalizedPrint SettingsPageStrings where
       STPSEnableRbfByDefault  -> "Отправлять RBF транзакции по умолчанию:"
       STPSSelectLanguage      -> "Выберите язык:"
       STPSTorStatus           -> "Статус подключения"
-      STPSTorEnable          -> "Подключить"
-      STPSTorDisable       -> "Отключить"
-      STPSTorEnabled        -> "Подключено:"
-      STPSTorDisabled     -> "Отключено"
+      STPSTorEnable           -> "Подключить"
+      STPSTorDisable          -> "Отключить"
+      STPSTorEnabled          -> "Подключено:"
+      STPSTorDisabled         -> "Отключено"
       STPSUseTor              -> "Проксировать через Tor"
       STPSSetsProxy           -> "Настройки прокси SOCKS"
       STPSProxyIpField        -> "Адрес прокси"
@@ -151,6 +152,28 @@ instance LocalizedPrint UnitBTC where
     BtcWhole    -> "BTC"
     BtcMilli    -> "mBTC"
     BtcSat      -> "sat"
+
+data NodeSetupStrings
+  = NDSSTitle Bool
+  | NDSSSwitchPub
+  | NDSSSetPriv
+  | NDSSSetNode
+  | NDSSCancel
+
+instance LocalizedPrint NodeSetupStrings where
+  localizedShow l v = case l of
+    English -> case v of
+      NDSSTitle m   -> "BTC nodes: " <> if m then "private" else "public" <> " mode"
+      NDSSSwitchPub -> "Switch to public mode"
+      NDSSSetPriv   -> "Setup private node"
+      NDSSSetNode   -> "Set node"
+      NDSSCancel    -> "Cancel"
+    Russian -> case v of
+      NDSSTitle m   -> "Ноды BTC: " <> if m then "приватный" else "публичный" <> " режим"
+      NDSSSwitchPub -> "Переключить на публичный режим"
+      NDSSSetPriv   -> "Настроить приватную ноду"
+      NDSSSetNode   -> "Установить ноду"
+      NDSSCancel    -> "Отмена"
 
 data NetSetupStrings
   = NSSTitle

--- a/wallet-types/ergvein-types.cabal
+++ b/wallet-types/ergvein-types.cabal
@@ -61,7 +61,6 @@ library
     , jsaddle
     , lens                      >= 4.17     && < 5.2
     , memory                    >= 0.14.16  && < 0.15.1
-    , network
     , string-conversions        >= 0.4.0.1  && < 0.4.0.2
     , text
     , time

--- a/wallet-types/src/Ergvein/Types/Storage/Currency/Public/Btc.hs
+++ b/wallet-types/src/Ergvein/Types/Storage/Currency/Public/Btc.hs
@@ -15,6 +15,7 @@ module Ergvein.Types.Storage.Currency.Public.Btc
   , btcPubStorage'possiblyReplacedTxs
   , btcPubStorage'restoreStartHeight
   , btcPubStorage'preferredNodes
+  , btcPubStorage'customNode
   ) where
 
 import Control.Lens
@@ -147,6 +148,8 @@ data BtcPubStorage = BtcPubStorage {
   , _btcPubStorage'restoreStartHeight :: !(Maybe Word64)
   -- | Preferred btc node adresses
   , _btcPubStorage'preferredNodes     :: !(Set Text)
+  -- | Custom BTC node. Maybe
+  , _btcPubStorage'customNode         :: !(Maybe Text)
   } deriving (Eq, Show, Read)
 
 instance SafeCopy BtcPubStorage where
@@ -161,12 +164,13 @@ instance SafeCopy BtcPubStorage where
     put _btcPubStorage'possiblyReplacedTxs
     put _btcPubStorage'restoreStartHeight
     put _btcPubStorage'preferredNodes
-  getCopy = contain $ BtcPubStorage <$> safeGet <*> safeGet <*> get <*> get <*> get <*> get <*> get <*> get <*> get
+    put _btcPubStorage'customNode
+  getCopy = contain $ BtcPubStorage <$> safeGet <*> safeGet <*> get <*> get <*> get <*> get <*> get <*> get <*> get <*> get
   kind = extension
 
 instance Migrate BtcPubStorage where
   type MigrateFrom BtcPubStorage = BtcPubStorage_V3
-  migrate (BtcPubStorage_V3 a b c d e f g h) = BtcPubStorage a b c d e f g h (S.fromList $ defBtcAddrs False)
+  migrate (BtcPubStorage_V3 a b c d e f g h) = BtcPubStorage a b c d e f g h (S.fromList $ defBtcAddrs False) Nothing
 
 -- This instances is required only for the current version
 makeLenses ''BtcPubStorage

--- a/wallet/src/Ergvein/Wallet/Page/Currencies.hs
+++ b/wallet/src/Ergvein/Wallet/Page/Currencies.hs
@@ -25,9 +25,9 @@ selectCurrenciesPage wt seedBackupRequired mnemonic = wrapperSimple True $ do
   void $ nextWidget $ ffor e $ \ac -> Retractable {
       retractableNext = if isAndroid
         -- On Android login is entered first. After that user is redirected to the password setup page.
-        then setupLoginPage wt seedBackupRequired Nothing mnemonic ac
+        then setupLoginPage wt seedBackupRequired Nothing mnemonic ac Nothing
         -- On desktop login and passwrod are entered on the same page.
-        else setupPasswordPage wt seedBackupRequired Nothing mnemonic ac Nothing
+        else setupPasswordPage wt seedBackupRequired Nothing mnemonic ac Nothing Nothing
     , retractablePrev = Nothing
     }
 

--- a/wallet/src/Ergvein/Wallet/Page/Seed.hs
+++ b/wallet/src/Ergvein/Wallet/Page/Seed.hs
@@ -86,8 +86,8 @@ mnemonicPage mMnemonic = wrapperSimple True $ do
 
 setLoginPasswordPage :: MonadFrontBase t m => WalletSource -> Bool -> Mnemonic -> m ()
 setLoginPasswordPage walletSource seedBackupRequired mnemonic = if isAndroid
-  then setupLoginPage walletSource seedBackupRequired Nothing mnemonic activeCurrencies
-  else setupPasswordPage walletSource seedBackupRequired Nothing mnemonic activeCurrencies Nothing
+  then setupLoginPage walletSource seedBackupRequired Nothing mnemonic activeCurrencies Nothing
+  else setupPasswordPage walletSource seedBackupRequired Nothing mnemonic activeCurrencies Nothing Nothing
   where activeCurrencies = [BTC]
 
 checkPageUnauth :: MonadFrontBase t m => Mnemonic -> m ()

--- a/wallet/src/Ergvein/Wallet/Password.hs
+++ b/wallet/src/Ergvein/Wallet/Password.hs
@@ -155,7 +155,9 @@ setupCustomNode mnode = mdo
       case mNamedSa of
         Nothing -> basicWidget Nothing PWSInvalidIP
         Just nsa -> do
-          node <- initBtcNode True 100 (namedAddrSock nsa) never True
+          -- This rating is irrelevant, since we don't actually keep the connection
+          let initRating = 100
+          node <- initBtcNode True initRating (namedAddrSock nsa) never True
           fmap join $ networkHoldDyn $ ffor (nodeconIsUp node) $ \case
             False -> basicWidget Nothing PWSNodeOffline
             True -> basicWidget (Just iptxt) (PWSNodeActive iptxt)

--- a/wallet/src/Ergvein/Wallet/Password.hs
+++ b/wallet/src/Ergvein/Wallet/Password.hs
@@ -13,6 +13,7 @@ module Ergvein.Wallet.Password(
   , askPasswordModal
   , setupLogin
   , setupDerivPrefix
+  , setupCustomNode
   , nameProposal
   , check
   ) where
@@ -25,6 +26,7 @@ import Data.Time (getCurrentTime)
 import Reflex.Localize.Dom
 
 import Ergvein.Aeson
+import Ergvein.Node.Resolve
 import Ergvein.Wallet.Localize
 import Ergvein.Wallet.Monad
 import Ergvein.Wallet.Page.PinCode
@@ -131,6 +133,68 @@ setupDerivPrefix ac mpath = do
       [] -> defaultDerivePath BTC
       [c] -> defaultDerivePath c
       _ -> defaultDerivPathPrefix
+
+data SetupAction = SACheck | SAClear | SASave Text
+  deriving (Eq, Show)
+
+setupCustomNode :: MonadFrontBase t m => Maybe Text -> m (Dynamic t (Maybe Text))
+setupCustomNode mnode = mdo
+  initE <- if isJust mnode then getPostBuild else pure never
+  let actE = leftmost [switchDyn $ snd <$> valD, SACheck <$ initE]
+  let clearE = ffilter (==SAClear) actE
+  mkLabel PWSCustomNodeDesc
+  nodeIpD <- labeledTextInput PWSCustomNode $ def
+    & textInputConfig_initialValue .~ fromMaybe "" mnode
+    & textInputConfig_setValue .~ ("" <$ clearE)
+  valD <- fmap join $ networkHold waitCheck $ ffor actE $ \case
+    SACheck -> do
+      iptxt <- sampleDyn nodeIpD
+      let port = if isTestnet then 18333 else 8333
+      resolver <- mkResolvSeed
+      mNamedSa <- resolveAddr resolver port iptxt
+      case mNamedSa of
+        Nothing -> basicWidget Nothing PWSInvalidIP
+        Just nsa -> do
+          node <- initBtcNode True 100 (namedAddrSock nsa) never True
+          fmap join $ networkHoldDyn $ ffor (nodeconIsUp node) $ \case
+            False -> basicWidget Nothing PWSNodeOffline
+            True -> basicWidget (Just iptxt) (PWSNodeActive iptxt)
+    SAClear -> waitCheck
+    SASave iptxt -> do
+      mkLabel $ PWSNodeSaved iptxt
+      actE' <- controlPanel Nothing
+      pure $ pure (Just iptxt, actE')
+  pure $ fst <$> valD
+  where
+    mkBtn :: MonadFrontBase t m => PasswordWidgetStrings -> m (Event t ())
+    mkBtn = submitClass "button button-outline"
+
+    mkLabel :: MonadFrontBase t m => PasswordWidgetStrings -> m ()
+    mkLabel = divClass "password-setup-descr" . h5 . localizedText
+
+    basicWidget :: MonadFrontBase t m
+      => Maybe Text
+      -> PasswordWidgetStrings
+      -> m (Dynamic t (Maybe Text, Event t SetupAction))
+    basicWidget mip lbl = do
+      mkLabel lbl
+      actE <- controlPanel mip
+      pure $ pure (Nothing, actE)
+
+    waitCheck :: MonadFrontBase t m => m (Dynamic t (Maybe Text, Event t SetupAction))
+    waitCheck = do
+      divClass "password-setup-descr" $ h5 $ localizedText PWSNodeFiller
+      actE <- fmap (SACheck <$) $ mkBtn PWSCheckNode
+      pure $ pure (Nothing, actE)
+
+    controlPanel :: MonadFrontBase t m => Maybe Text -> m (Event t SetupAction)
+    controlPanel mip = divClass "" $ do
+      checkE <- fmap (SACheck <$) $ mkBtn PWSCheckNode
+      clearE <- fmap (SAClear <$) $ mkBtn PWSCancelNode
+      saveE <- case mip of
+        Nothing -> pure never
+        Just ip -> fmap (SASave ip <$) $ mkBtn PWSSaveNode
+      pure $ leftmost [checkE, clearE, saveE]
 
 askPasswordWidget :: MonadFrontBase t m => Text -> Bool -> Event t () -> m (Event t Password)
 askPasswordWidget name writeMeta clearInputE


### PR DESCRIPTION
This PR adds custom/private node functionality.

If a private node is set, all requests are routed to the private node.

The user can set up a private node before restoring or creating the wallet in advanced settings.

The user can switch back and forth between private and public modes and can also change private node without switching between modes