### PR TITLE
Add remove button for stale transactions

### DIFF
--- a/checkpoint-generator/ergvein-checkpoint-generator.cabal
+++ b/checkpoint-generator/ergvein-checkpoint-generator.cabal
@@ -22,7 +22,7 @@ library
       , bytestring        >= 0.10    && < 0.11
       , cereal            >= 0.5     && < 0.6
       , conduit           >= 1.3     && < 1.4
-      , cryptonite        >= 0.25    && < 0.26
+      , cryptonite        >= 0.25    && < 0.28
       , hexstring         >= 0.11    && < 0.12
       , memory            >= 0.14    && < 0.16
       , split             >= 0.2     && < 0.3

--- a/data-merkle-tree/data-merkle-tree.cabal
+++ b/data-merkle-tree/data-merkle-tree.cabal
@@ -19,7 +19,7 @@ library
       base         >= 4.7   && < 4.13
     , bytestring   >= 0.10  && < 0.11
     , cereal       >= 0.5   && < 0.6
-    , cryptonite   >= 0.25  && < 0.26
+    , cryptonite   >= 0.25  && < 0.28
     , deepseq      >= 1.4   && < 1.5
     , memory       >= 0.14  && < 0.16
     , text         >= 1.2   && < 1.3

--- a/ergvein-core/src/Ergvein/Core/Client/Socket.hs
+++ b/ergvein-core/src/Ergvein/Core/Client/Socket.hs
@@ -107,7 +107,7 @@ initIndexerConnection sname sa msgE = mdo
     _ -> pure Nothing
   let sendE = leftmost [handshakeE, hsRespE, gate (current shakeD) reqE]
 
-  performEvent_ $ ffor sendE $ nodeLog sa . ("Sending message: " <>) . showt
+  -- performEvent_ $ ffor sendE $ nodeLog sa . ("Sending message: " <>) . showt
   performEvent_ $ ffor (_socketRecvEr s) $ nodeLog sa . showt
 
   -- Track handshake status

--- a/ergvein-core/src/Ergvein/Core/Node/Socket.hs
+++ b/ergvein-core/src/Ergvein/Core/Node/Socket.hs
@@ -143,14 +143,14 @@ socket SocketConf{..} = fmap switchSocket $ networkHoldDyn $ ffor _socketConfPro
   sendChan <- liftIO newTChanIO
   performEvent_ $ ffor closeE $ const $ liftIO $ atomically $ writeTVar intVar True
   performEvent_ $ ffor _socketConfSend $ \bs -> do
-    logWrite $ "Serialized message: " <> showt bs
+    -- logWrite $ "Serialized message: " <> showt bs
     liftIO . atomically . writeTChan sendChan $ bs
   performEvent_ $ ffor _socketConfClose $ const $ liftIO $ closeCb Nothing
   performFork_  $ ffor connectE $ const $ liftIO $ do
     let sendThread sock = forever $ do
-          logWrite "Awaiting messages to send"
+          -- logWrite "Awaiting messages to send"
           msgs <- atomically $ readAllTVar sendChan
-          logWrite $ "Sending messages with length: " <> showt (BS.length <$> msgs)
+          -- logWrite $ "Sending messages with length: " <> showt (BS.length <$> msgs)
           traverse_ (sendAll sock) msgs
           -- sendLazy sock . BSL.fromChunks $ msgs
         conCb (sock, _) = do

--- a/ergvein-core/src/Ergvein/Core/Scan.hs
+++ b/ergvein-core/src/Ergvein/Core/Scan.hs
@@ -169,7 +169,7 @@ scanBtcBlocks keys hashesE = do
   performEvent_ $ ffor txsUpdsE $ \(upds, _) -> logWrite $ "Transactions got: " <> showt (mconcat . V.toList . fmap snd $ upds)
   storeUpdated1E <- insertTxsUtxoInPubKeystore "scanBtcBlocks" BTC txsUpdsE
   updD <- holdDyn (error "impossible: scanBtcBlocks") storeUpdated1E
-  outUpdE <- removeOutgoingTxs "scanBtcBlocks" BTC $ (M.elems . M.unions . V.toList . snd . V.unzip . fst) <$> storeUpdated1E
+  outUpdE <- removeOutgoingTxs "scanBtcBlocks" BTC $ (fmap egvTxId . M.elems . M.unions . V.toList . snd . V.unzip . fst) <$> storeUpdated1E
   let storeUpdated2E = tag (current updD) outUpdE
   pure $ leftmost [(V.any (not . M.null . snd)) . fst <$> storeUpdated2E, False <$ noScanE]
 

--- a/ergvein-localize/src/Ergvein/Wallet/Localize/History.hs
+++ b/ergvein-localize/src/Ergvein/Wallet/Localize/History.hs
@@ -5,6 +5,7 @@ module Ergvein.Wallet.Localize.History
     HistoryPageStrings(..)
   , HistoryTitle(..)
   , BumpFeeWidgetStrings(..)
+  , RemoveTxWidgetStrings(..)
   ) where
 
 import Data.Word
@@ -41,6 +42,7 @@ data HistoryPageStrings =
   | HistoryTIFee
   | HistoryTIRbf
   | HistoryTIBumpFeeBtn
+  | HistoryTIRemoveBtn
   | HistoryTIConflictingTxs
   | HistoryTIReplacedTxs
   | HistoryTIPossiblyReplacedTxs
@@ -78,6 +80,7 @@ instance LocalizedPrint HistoryPageStrings where
       HistoryTIFee                 -> "Fee"
       HistoryTIRbf                 -> "Replace by fee"
       HistoryTIBumpFeeBtn          -> "Bump fee"
+      HistoryTIRemoveBtn           -> "Remove"
       HistoryTIConflictingTxs      -> "Conflicting transactions"
       HistoryTIReplacedTxs         -> "Replaced transactions"
       HistoryTIPossiblyReplacedTxs -> "The transaction may have replaced these transactions or was replaced by one of them"
@@ -112,6 +115,7 @@ instance LocalizedPrint HistoryPageStrings where
       HistoryTIFee                 -> "Комиссия"
       HistoryTIRbf                 -> "Replace by fee"
       HistoryTIBumpFeeBtn          -> "Увеличить комиссию"
+      HistoryTIRemoveBtn           -> "Удалить"
       HistoryTIConflictingTxs      -> "Конфликтующие транзакции"
       HistoryTIReplacedTxs         -> "Замененные транзакции"
       HistoryTIPossiblyReplacedTxs -> "Эта транзакция заменила следующие транзакции или была заменена одной из них"
@@ -205,3 +209,27 @@ instance LocalizedPrint BumpFeeWidgetStrings where
       BumpFeeSignTx                      -> "Подписать транзакцию"
       BumpFeeTitle                       -> "Увеличение комиссии"
       BumpFeeTxId                        -> "ID транзакции"
+
+data RemoveTxWidgetStrings =
+    RemoveTxTitle
+  | RemoveTxHeader
+  | RemoveTxBody
+  | RemoveTxAgree
+  | RemoveTxCancel
+  deriving (Eq)
+
+instance LocalizedPrint RemoveTxWidgetStrings where
+  localizedShow l v = case l of
+    English -> case v of
+      RemoveTxTitle    -> "Remove tx"
+      RemoveTxHeader   -> "Are you sure to remove the transaction?"
+      RemoveTxBody     -> "If the transaction is in mempool, it can still appear even after removal. If a miner publishes a block with the transaction, it will appear again in your wallet. You should delete only those transactions that are stale and are not accepted by the network."
+      RemoveTxAgree    -> "Delete it"
+      RemoveTxCancel   -> "Cancel"
+
+    Russian -> case v of
+      RemoveTxTitle    -> "Удалить транзакцию"
+      RemoveTxHeader   -> "Вы точно уверены?"
+      RemoveTxBody     -> "Если транзакция попала в мемпул, то она всё ещё может подтвердиться. Если майнер опубликует блок с этой транзакцией, то она снова появится в вашем кошельке. Удаляйте только те транзакции, что застряли и точно не находятся в мемпуле."
+      RemoveTxAgree    -> "Удалить её"
+      RemoveTxCancel   -> "Отмена"

--- a/ui-playground/Style.hs
+++ b/ui-playground/Style.hs
@@ -126,6 +126,7 @@ frontendCss r = do
   historyPageCss
   txInfoPageCss
   bumpFeePageCss
+  removeTxPageCss
   infoPageCss
   initialPageCss
   inputCss
@@ -1027,6 +1028,11 @@ bumpFeePageCss :: Css
 bumpFeePageCss = do
   ".bump-fee-page" ? do
     textAlign $ alignSide sideLeft
+
+removeTxPageCss :: Css
+removeTxPageCss = do
+  ".remove-tx-page" ? do
+    textAlign $ alignSide sideCenter
 
 legoStyles :: Css
 legoStyles = do

--- a/wallet/ergvein-wallet.cabal
+++ b/wallet/ergvein-wallet.cabal
@@ -59,6 +59,7 @@ library
         Ergvein.Wallet.Page.Settings.Unauth
         Ergvein.Wallet.Page.TxInfo.Btc
         Ergvein.Wallet.Page.TxInfo.Common
+        Ergvein.Wallet.Page.TxInfo.Remove
         Ergvein.Wallet.Password
         Ergvein.Wallet.Settings
         Ergvein.Wallet.Status.Widget

--- a/wallet/src/Ergvein/Wallet/Page/TxInfo/Remove.hs
+++ b/wallet/src/Ergvein/Wallet/Page/TxInfo/Remove.hs
@@ -1,0 +1,41 @@
+{-# OPTIONS_GHC -Wall #-}
+
+module Ergvein.Wallet.Page.TxInfo.Remove(
+    removeTxPage
+  ) where
+
+import Control.Monad.Reader
+import Data.Bifunctor (first)
+import Data.Word
+
+import Ergvein.Core.Transaction.View.Btc
+import Ergvein.Maybe
+import Ergvein.Types.Utxo.Btc
+import Ergvein.Wallet.Language
+import Ergvein.Wallet.Localize
+import Ergvein.Wallet.Monad
+import Ergvein.Wallet.Settings
+import Ergvein.Wallet.Validate
+import Ergvein.Wallet.Widget.Input.Fee
+import Ergvein.Wallet.Wrapper
+import Sepulcas.Alert
+import Sepulcas.Elements
+
+import Network.Haskoin.Network (Inv(..), InvVector(..), InvType(..), Message(..))
+
+import qualified Data.List as L
+import qualified Network.Haskoin.Transaction as HT
+
+removeTxPage :: MonadFront t m => Currency -> TxId -> m ()
+removeTxPage cur tx = do
+  title <- localized RemoveTxTitle
+  let thisWidget = Just . pure $ removeTxPage cur tx
+  wrapper False title thisWidget $ divClass "remove-tx-page" $ do
+    elClass "h4" "mb-1" $ localizedText RemoveTxHeader
+    elClass "h5" "mb-1" $ localizedText RemoveTxBody
+    divClass "fit-content ml-a mr-a" $ do
+        cancelE <- outlineButton RemoveTxCancel
+        removeE <- outlineButton RemoveTxAgree
+        removedE' <- removeOutgoingTxs "removeTxPage" cur $ [tx] <$ removeE
+        removedE <- removeStorageTx "removeTxPage" cur $ tx <$ removedE'
+        void $ retract $ leftmost [cancelE, removedE]


### PR DESCRIPTION
Now you can find a remove button for unconfirmed outgoing transactions to be able to fast clean stale transactions that are rejected from mempool.

User is warned about deletion before the action.