### PR TITLE
Bump version for reflex-0.9.*

### DIFF
--- a/reflex-localize/CHANGELOG.md
+++ b/reflex-localize/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.2.0.0
+
+* Raise bounds for `reflex-0.9`
+
 # 1.1.0.0
 
 * Added instance for `LocalizedPrint ()`

--- a/reflex-localize/reflex-localize.cabal
+++ b/reflex-localize/reflex-localize.cabal
@@ -1,5 +1,5 @@
 name:                reflex-localize
-version:             1.1.0.0
+version:             1.2.0.0
 synopsis:            Localization library for reflex
 description:         Library provides helpers for dynamic strings that depends on current selected language.
   See also `reflex-localize-dom` for examples and DOM related helpers.
@@ -37,9 +37,10 @@ library
       base                      >= 4.5      && < 4.15
     , jsaddle
     , mtl
-    , reflex                    >= 0.4      && < 0.9
+    , reflex                    >= 0.4      && < 0.10
     , reflex-external-ref
     , text
+    , commutative-semigroups
   default-language:    Haskell2010
   default-extensions:
     CPP

--- a/reflex-localize/src/Reflex/Localize/Trans.hs
+++ b/reflex-localize/src/Reflex/Localize/Trans.hs
@@ -19,6 +19,10 @@ import Reflex.ExternalRef
 import Reflex.Localize.Language
 import Reflex.Localize.Monad
 
+#if MIN_VERSION_reflex(0,9,0)
+import Data.Semigroup.Commutative (Commutative)
+#endif 
+
 data LocalizeEnv t = LocalizeEnv {
   locEnvLangRef :: !(ExternalRef t Language)
 } deriving (Generic)
@@ -41,7 +45,11 @@ deriving instance MonadIO m => MonadIO (LocalizeT t m)
 #ifndef ghcjs_HOST_OS
 deriving instance MonadJSM m => MonadJSM (LocalizeT t m)
 #endif
+#if MIN_VERSION_reflex(0,9,0)
+deriving instance (Group q, Commutative q, Query q, Eq q, MonadQuery t q m, Monad m) => MonadQuery t q (LocalizeT t m)
+#else 
 deriving instance (Group q, Additive q, Query q, Eq q, MonadQuery t q m, Monad m) => MonadQuery t q (LocalizeT t m)
+#endif
 deriving instance (Monoid w, DynamicWriter t w m) => DynamicWriter t w (LocalizeT t m)
 #if !MIN_VERSION_reflex(0,7,0)
 deriving instance (Monoid w, MonadBehaviorWriter t w m) => MonadBehaviorWriter t w (RetractT t m)


### PR DESCRIPTION
Allows building with recent `reflex` 